### PR TITLE
docs: spec refatoração Uazapi (schedule, materialize, resiliência)

### DIFF
--- a/docs/UAZAPI_SCHEDULE_CHUNKS_MATERIALIZE_EXPLORATORY.md
+++ b/docs/UAZAPI_SCHEDULE_CHUNKS_MATERIALIZE_EXPLORATORY.md
@@ -1,0 +1,208 @@
+# Uazapi — análise exploratória: schedule, chunks e materialização
+
+Documento de mapeamento do **comportamento atual** do código (sem refatoração), alinhado ao pedido de análise de `campaign_stage_sends`, `worker_cadence`, sync Uazapi e `create_advanced_campaign`.
+
+---
+
+## 1. Mapa do fluxo end-to-end
+
+### 1.1 Visão resumida (ordem de execução no worker)
+
+O loop principal é `process_cadence` em `worker_cadence.py`.
+
+```mermaid
+flowchart TD
+  A[process_cadence] --> B[_recover_stale_scheduled_initial_uazapi_sends]
+  B --> C[_materialize_scheduled_stage_sends]
+  C --> D[_process_verify_folder_queue]
+  D --> E{STAGE_SYNC_INTERVAL?}
+  E -->|~10 min| F[_sync_active_stage_folders]
+  E -->|senão skip| G[check_monitoring_leads]
+  F --> G
+  G --> H[process_uazapi_initial_stage_rollovers]
+  H --> I[Para cada campanha: schedule_next_initial_chunk OU process_rollover]
+  I --> J[enable_cadence: FU chain + process_campaign_sends]
+```
+
+### 1.2 Onde o próximo chunk é agendado (`scheduled_for`, BRT, cota)
+
+| Peça | Arquivo / função | Papel |
+| --- | --- | --- |
+| Slot “matinal” e mesmo dia (D1) | `utils/initial_chunk_schedule_target.py` — `cadence_next_initial_send_slot`, `resolve_initial_chunk_schedule_target`, `uazapi_same_day_initial_chunk_after_unlock_enabled` | Define o instante alvo (BRT) **antes** do `INSERT` em `campaign_stage_sends`. O env `UAZAPI_SAME_DAY_INITIAL_CHUNK_AFTER_UNLOCK` permite chunk no mesmo dia após o horário de início, se janela BRT + cota permitirem. |
+| Normalização para UTC naive + janela válida | `utils/next_valid_uazapi_send.py` — `next_valid_send_utc_naive` (usada em `schedule_next_initial_chunk` e em stale recovery) | Garante que o `scheduled_for` gravado cai numa janela de envio da campanha. |
+| Cota diária (TD-12 / G2 default) | `utils/limits.py` — `check_initial_chunk_daily_quota_for_campaign`; `utils/campaign_send_policy.py` — `INITIAL_CHUNK_DAILY_QUOTA_POLICY`, `initial_chunk_daily_quota_allows` | `schedule_next_initial_chunk` e `_recover_stale_scheduled_initial_uazapi_sends` consultam a cota; **inserção automática** do próximo chunk usa a cota no ramo D1. API `continue-initial-chunk` em `app.py` também bloqueia com **429** se a cota não permitir. |
+| “Chunk ativo” bloqueia duplicar na mesma instância | `utils/limits.py` — `INITIAL_CHUNK_ACTIVE_SEND_STATUSES` = `scheduled`, `running`, `partial`, `queued` | `schedule_next_initial_chunk` e `_continue_initial_chunk_core` (app) só inserem nova linha se **não** houver send nesse conjunto de status para `(campaign_id, stage, instance_id)`. `failed` / `done` **não** bloqueiam. |
+| Janela BRT no momento de materializar (não no INSERT) | `worker_cadence.py` — `_materialize_scheduled_stage_sends` + `is_campaign_send_window` / `next_valid_send_utc_naive` (margem `MATERIALIZE_LOOKAHEAD_MIN`) | Se na hora do materialize estiver fora da janela: **bump** de `scheduled_for` para o próximo `next_valid` **ou** `status = failed` se a janela for inválida. |
+
+**Nota importante:** `can_create_campaign_today` em `utils/limits.py` **sempre retorna `True`**; comentário explícito de que o limite antigo por instância/dia foi removido. O gate de volume “real” é a política TD-12 + `daily_limit` da campanha, não esse helper (ainda referenciado em comentários em `initial_chunk_schedule_target.py`).
+
+### 1.3 Janela de materialize automático (UTC)
+
+Definida em `worker_cadence.py` (cabeçalho e docstring de `_materialize_scheduled_stage_sends`):
+
+- `MATERIALIZE_LOOKBACK_MIN` = 15
+- `MATERIALIZE_LOOKAHEAD_MIN` = 5
+
+A query SQL (modo automático) filtra `campaign_stage_sends` com `status = 'scheduled'`, `uazapi_folder_id` NULL, `scheduled_for` entre `now_utc - lookback` e `now_utc + lookahead`. O loop Python aplica o mesmo corte em `remaining` (segundos) para evitar drift entre SQL e processamento.
+
+**Efeito prático:** se um `scheduled_for` cair fora da janela (ex.: atraso > 15 min sem tick), a linha **não** é materializada pelo worker nesse passo; entra o fluxo de **stale recovery** (abaixo).
+
+### 1.4 Onde `create_advanced_campaign` roda, persistência de `uazapi_folder_id`
+
+- **Serviço HTTP:** `services/uazapi.py` — `UazapiService.create_advanced_campaign` → `POST /sender/advanced` (`timeout=30`); em erro HTTP ou exceção de transporte retorna **`None`** (não levanta para o worker).
+- **Gravação na linha do chunk:** `worker_cadence.py` — `_materialize_scheduled_stage_sends`, após sucesso: `UPDATE campaign_stage_sends` com `uazapi_folder_id`, `instance_remote_jid`, `lead_ids`, `planned_count`, `status = 'running'`, etc.; e `INSERT INTO uazapi_instance_sends` para estatística por instância/dia.
+- **Pós-API “queued/scheduled”:** se `result.status` ∈ `queued`, `scheduled`, chama `edit_campaign(..., "continue")` para despertar o envio.
+- **Rolos FU / legacy:** `process_uazapi_initial_stage_rollovers`, `process_rollover`, `process_rollover_fu_next` também chamam `create_advanced_campaign` com contexto FU1/FU2/breakup.
+
+### 1.5 Falha de materialize: estado da linha e `lead_ids`
+
+Cenário `_materialize_scheduled_stage_sends` após chamar a API (resumo):
+
+| Situação | Efeito na linha `campaign_stage_sends` | `lead_ids` |
+| --- | --- | --- |
+| `create_advanced_campaign` retorna vazio/sem `folder_id` (ex.: 500, timeout, 401 — em todos os casos `UazapiService` devolve `None`) | `status = 'failed'` (UPDATE por `send_id`) | **Não** preenchido neste caminho; permanece o que estava (muitas vezes `[]` do INSERT inicial) |
+| 0 leads elegíveis (mesmo `scheduled_for` / etapa) | `UPDATE` em massa: `status = 'failed'` para o grupo `(campaign_id, stage, scheduled_for)` | Inalterado |
+| `chunk` vazio para uma instância (índice) | `status = 'done'`, `planned_count = 0` | Inalterado |
+| Sem mensagens step | `status = 'failed'` | Inalterado |
+| Sem `apikey` | `status = 'failed'` | Inalterado |
+| Fora da janela BRT (sem `ValueError` no `next_valid`) | `scheduled_for` = próximo `next_valid` (bump) | Inalterado até o materialize bem-sucedido gravar `lead_ids` |
+| Fora da janela BRT e janela de campanha inválida | `status = 'failed'` | Inalterado |
+| `can_create_campaign_today` falso | **Código:** `can_create_campaign_today` é sempre `True` — ramo inalcançável no estado atual, salvo mudança futura em `limits.py` | — |
+
+O **break** após falha no primeiro segmento de pacing interrompe o laço de segmentos para aquele `send_id` (comportamento documentado no código: falha cedo).
+
+### 1.6 Pré-sync antes de novo folder (Task 6)
+
+- `utils/sync_uazapi.py` — `sync_campaign_stage_sends_before_new_chunk`  
+  Condição: env `UAZAPI_RECONCILE_FIND_BEFORE_CHUNK` default `1`; exige `campaign` com send prévio **com** `uazapi_folder_id` na etapa. Chama `sync_campaign_leads_from_uazapi` com `campaigns.uazapi_folder_id` (primeira instância com apikey) para reconciliar antes de outro `create_advanced_campaign`.
+
+- Chamado de: `_materialize_scheduled_stage_sends` (por grupo de campanha/etapa), `schedule_next_initial_chunk`, e caminhos em `app.py` documentados (ex. FU imediato).
+
+Falha no pré-sync: em `_materialize` faz `rollback` e log `uazapi_materialize_pre_sync_failed` — o fluxo de materialize **continua** (não retorna cedo em todos os trechos; ver logs).
+
+### 1.7 Sync periódico, rollover e contadores de chunk
+
+- **`_sync_active_stage_folders` (`worker_cadence.py`)**  
+  A cada `STAGE_SYNC_INTERVAL_MINUTES` (10), para sends com `status IN ('scheduled','running','partial')` e `uazapi_folder_id` não nulo e `last_sync_at` antigo, chama `sync_campaign_leads_from_uazapi` na pasta da **campanha** (`campaigns.uazapi_folder_id`).
+
+- **Fonte de verdade agregada:** comentários em `utils/sync_uazapi.py` e `worker_cadence.py` — `GET /sender/listfolders` (`log_sucess`, `log_failed`, `log_total`, status da pasta). `listmessages` não substitui totais oficiais.
+
+- **`process_uazapi_initial_stage_rollovers`:** considera sends `initial` com `status IN ('done','partial')`, `fu_rollover_done = false`, `enable_cadence` e Uazapi. Rollover quando `success_count + failed_count >= planned_count`. Opcional: `sync_campaign_leads_from_uazapi` antes, se `UAZAPI_RECONCILE_FIND_BEFORE_ROLLOVER`; gate `should_block_initial_rollover_for_pending_find` (message_find / D9).
+
+- **Fila pós-create:** `_process_verify_folder_queue` — ~3 min após create, `list_folders` para verificar se a pasta existe (só log).
+
+---
+
+## 2. Tabela: cenário → comportamento atual → gap
+
+| Cenário | O que o código faz hoje | Gaps / observações |
+| --- | --- | --- |
+| **A. Instância desconectada / API 500 com `{"error":"No session"}`** | `create_advanced_campaign` recebe status ≠ 200, `raise_for_status` → exceção → retorno **`None`**. Materialize trata como falha: `status = 'failed'`, **sem** pasta. Não diferencia "No session" de outro 500 no retorno. | Operador: chunk `failed` sem `uazapi_folder_id`. Próximo chunk: só quando `schedule_next_initial_chunk` inserir de novo (não re-tenta sozinho no mesmo minuto). |
+| **B. Timeout ou 5xx genérico Uazapi** | Idem: `None` → linha `failed`. Logs em stderr da app/worker. | Idem. Sem classificação retryable vs terminal no código do cliente. |
+| **C. `scheduled` + `planned_count > 0` com `uazapi_folder_id` NULL após N min** | O INSERT de `schedule_next_initial_chunk` usa `planned_count = 0` e `lead_ids = '[]'`. O `planned_count` preenche **após** create bem-sucedido. Cenário real: linha fica `scheduled` sem pasta **e** 0 planeado — típico de: (1) ainda na janela de espera, (2) fora da janela UTC de materialize, (3) stale > TTL. Recovery: `_recover_stale_scheduled_initial_uazapi_sends` se `scheduled_for < now - 90 min` (env `UAZAPI_STALE_RECOVERY_TTL_MINUTES`): bump `scheduled_for` para `next_valid` **ou** `failed` (sem apikey, janela inválida, modo `mark_failed`). | Se N < TTL, a linha pode **permanecer** `scheduled` sem pasta (até entrar no materialize + lookback/lookahead). Admin: tabela de chunks mostra `scheduled` / pasta vazia. |
+| **D. Pasta criada, envio parcial (`success` + `failed` vs `planned`)** | Sync (`sync_campaign_leads_from_uazapi`) atualiza contagens a partir de listfolders (cap em `planned_count`) e `message_find` em estados D4. Rollover inicial: promove FU1 quando `succ + fail >= planned` — **falhas parciais na API não bloqueiam** avanço para quem recebeu envio. Leads que falharam na API podem permanecer em Inicial conforme reconciliação. | Operador pode ver `partial` e contagens; precisa de sync para alinhar leads. Documentado em docstrings do rollover. |
+| **E. “Dia seguinte” após falha (produção)** | `schedule_next_initial_chunk` coloca o próximo slot em geral com `cadence_next_initial_send_slot` → **um slot matinal no dia seguinte** (a menos que D1 + env + cota + janela permitam mesmo dia). `failed` **não** bloqueia nova linha. Se o operador **não** tiver cota / slot no mesmo dia, o próximo INSERT será naturalmente D+1. | Comportamento esperado dado o desenho “um insert automático por dia civil” + stale bump para `next_valid` (pode ser amanhã no início da janela). |
+
+**Admin (UI):** `templates/admin/campaigns.html` mostra colunas de stage, `scheduled_for`, `status`, contadores, `uazapi_folder_id`. Rota de flush stale em `app.py` chama `_recover_stale_scheduled_initial_uazapi_sends` com modos `recovery` / `mark_failed` (auditoria `admin_uazapi_stale_flush_audit`).
+
+**API “Continuar chunk”:** `app.py` — `POST /api/campaigns/<id>/continue-initial-chunk` → `_continue_initial_chunk_core` insere `scheduled` e chama `_materialize_scheduled_stage_sends(conn, force_send_ids=...)`. Respostas **200 / 207 / 502** conforme `utils/continue_initial_chunk_report.py` e presença de exceção na materialização imediata.
+
+---
+
+## 3. Débito técnico explícito
+
+| Tema | Onde aparece |
+| --- | --- |
+| **Regras duplicadas (continuar vs worker)** | `schedule_next_initial_chunk` e `_continue_initial_chunk_core` repetem: instâncias Uazapi, delays, `INITIAL_CHUNK_ACTIVE_SEND_STATUSES`, carga de mensagens step 1, INSERT de `campaign_stage_sends` — o app força janela com `now+30s` ou `next_valid` com margem `MATERIALIZE_LOOKAHEAD_MIN` quando fora da janela BRT. |
+| **Janelas materialize (lookahead/lookback)** | Constantes só em `worker_cadence.py`; comentário “SSOT” compartilhada entre SQL e Python. Qualquer `INSERT` de `scheduled_for` em `app.py` deve cair no intervalo de materialize automático ou depender de `force_send_ids` / tick seguinte. |
+| **`can_create_campaign_today` obsoleto** | `utils/limits.py` — retorno fixo `True`; materialize ainda contém o ramo condicional (inalcançável). Comentários em `initial_chunk_schedule_target.py` alertam. |
+| **Múltiplas camadas de feature flags** | `UAZAPI_SAME_DAY_INITIAL_CHUNK_AFTER_UNLOCK`, `UAZAPI_STALE_RECOVERY_*`, `UAZAPI_RECONCILE_FIND_BEFORE_ROLLOVER`, `UAZAPI_RECONCILE_FIND_BEFORE_CHUNK`, `UAZAPI_LEAD_RECONCILE_V2`, `UAZAPI_MESSAGE_FIND`, etc. — espalhadas com defaults distintos; risco de comportamento “depende do ambiente”. |
+| **TODOs / Task labels** | Docstrings em `worker_cadence.py` e `utils/sync_uazapi.py` referem Task 3/5/6/7, D1, D3, D4, D9, D10, F7, F10, T6–T10 — úteis para rastreio, mas misturam spec de produto e código. |
+| **Dois caminhos de rollover “Inicial → FU”** | `process_uazapi_initial_stage_rollovers` (cadência + Uazapi) vs `process_rollover` (rollover diário + list_messages Sent) — campanhas/configurações diferentes. |
+
+---
+
+## 4. Jornada ideal (recomendação de comportamento — sem implementar)
+
+**Princípio:** separar **(a) saúde da conexão WhatsApp**, **(b) transiente de API**, e **(c) política de agendamento de negócio** (cota, janela BRT, anti-spam).
+
+### 4.1 P0 (confiança operacional e recuperação)
+
+1. **Classificação de erro em `create_advanced_campaign`:** persistir categoria (`no_session` vs `timeout` vs `5xx` vs `4xx`) para métricas e **retry** distinto. Hoje tudo vira `None` + `failed` genérico.
+2. **“No session” / desconectado:** não tratar como falha terminal de negócio da mesma forma que validação: preferir `scheduled` com `scheduled_for` curto (backoff) + mensagem clara no admin, ou flag explícita `last_error_code` na linha do chunk.
+3. **Staleness sem surpresa:** alinhar expectativa: ou TTL < janela de materialize com bump agressivo, ou alerta proativo se `scheduled` sem pasta e `now - scheduled_for` > X minutos.
+4. **Uma fonte de verdade** para “posso criar outro chunk nesta instância?” (já existe `INITIAL_CHUNK_ACTIVE_SEND_STATUSES`; evitar duplicar condições em outro módulo).
+
+### 4.2 P1 (UX e alinhamento produto)
+
+1. **Rationale no admin** quando `scheduled` sem pasta: exibir *porquê* (fora de janela UTC, aguardando token, cota, stale recovery na próxima iteração).
+2. **Continuar chunk** (API) + worker: resposta 207/502 já dão pistas; unificar com mensagens de *instância desconectada* se o backend obtiver `get_status` opcionalmente antes de POST (custo: mais chamada HTTP).
+3. **Cota (G2)** e **D1** documentados no painel: operador entende D+1 vs mesmo dia.
+4. **Rollover com parcial:** UI já mostra contadores; especificar *copy* de que leads falhos na Uazapi podem ficar na Inicial até nova ação (comportamento atual do rollover).
+
+### 4.3 Ordem de prioridade sugerida
+
+| Prioridade | Item |
+| --- | --- |
+| **P0** | Observabilidade e taxonomia de erros de materialize; retentativas com backoff para erros conhecidos de sessão/5xx. |
+| **P0** | Revisar interação **stale recovery** (90 min) × **janela materialize** (15 min) — hoje gera estados “presos” conhecidos. |
+| **P1** | Unificar regra de agendamento entre `app` e `worker` (helper único de “próximo `scheduled_for`”). |
+| **P1** | Remover ou reimplementar `can_create_campaign_today` se não tiver efeito. |
+| **P2** | Documentar flags em um único `docs/` ou tabela de env (reduzir surpresas entre ambientes). |
+
+---
+
+## 5. Riscos (residuais)
+
+- **Janela UTC de materialize estreita:** chunks que “ficam para trás” > 15 min dependem de stale recovery ou de `force` via continue API; risco de operador ver linhas `scheduled` sem ação.
+- **Dupla natureza de `listfolders`:** se a API atrasar ou retornar lista sem a pasta, sync pode atrasar reconciliação (comentários já admitem “próximo listfolders ~10 min”).
+- **Pacing (múltiplos segmentos):** primeiro segmento com falha dá `break` — restantes daquele send podem não ser criados naquele passo.
+- **Segurança/operacional:** admin stale flush e force de campanha fora de `running|pending|completed` podem marcar `failed` em massa; existe auditoria, mas requer *runbook*.
+
+---
+
+## 6. Sugestão de testes
+
+### 6.1 Já existentes (referência)
+
+- `tests/test_worker_cadence_initial_chunk.py` — `INITIAL_CHUNK_ACTIVE_SEND_STATUSES`
+- `tests/test_worker_materialize_outside_brt.py` — materialize fora da janela BRT
+- `tests/test_worker_stale_recovery.py` — recovery de scheduled stale
+- `tests/test_sync_uazapi.py` — amplo cobertura de sync / message_find / orfãos
+- `tests/test_continue_initial_chunk_ac13.py` — outcomes por instância após continuar
+- `tests/test_campaign_send_policy.py` — política G1/G2/G3 e `check_initial_chunk_daily_quota_for_campaign`
+
+### 6.2 Manuais sugeridos
+
+1. **Desconectar** instância na Uazapi → deixar worker passar → verificar `campaign_stage_sends` (esperado: `failed` após materialize, sem `uazapi_folder_id`).
+2. **Simular** resposta 500 (mock ou proxy) no `/sender/advanced` → mesma verificação.
+3. **Chunk `scheduled` com `scheduled_for` no passado** > 90 min → após tick, verificar bump de `scheduled_for` ou `failed` conforme quota/apikey.
+4. **Criar pasta com sucesso** e interromper envio parcial → sync manual (rota ou worker) → contadores e `partial` / rollover.
+
+### 6.3 Automatizados (ideias)
+
+- **Unit:** mock de `UazapiService.create_advanced_campaign` retornando `None` e assert de `UPDATE ... status = 'failed'` em harness DB ou mock de cursor (padrão dos testes de `test_worker_*`).
+- **Unit:** `classify_initial_chunk_send_row` para combinações `scheduled` com e sem `uazapi_folder_id` (já parcialmente em `test_continue_initial_chunk_ac13`).
+- **Integração (se houver):** `process_cadence` com ordem garantida recovery → materialize, verificando que `force_send_ids` ignora janela (como em testes de materialize).
+
+---
+
+## 7. Índice de símbolos (localização rápida)
+
+| Símbolo / conceito | Local principal |
+| --- | --- |
+| `process_cadence`, `_materialize_scheduled_stage_sends`, `schedule_next_initial_chunk`, `process_uazapi_initial_stage_rollovers` | `worker_cadence.py` |
+| `MATERIALIZE_LOOKAHEAD_MIN`, `MATERIALIZE_LOOKBACK_MIN` | `worker_cadence.py` |
+| `_recover_stale_scheduled_initial_uazapi_sends` | `worker_cadence.py` |
+| `sync_campaign_leads_from_uazapi`, `sync_campaign_stage_sends_before_new_chunk` | `utils/sync_uazapi.py` |
+| `create_advanced_campaign`, `list_folders` | `services/uazapi.py` |
+| `INITIAL_CHUNK_ACTIVE_SEND_STATUSES`, `check_initial_chunk_daily_quota_for_campaign` | `utils/limits.py` |
+| `resolve_initial_chunk_schedule_target`, `cadence_next_initial_send_slot` | `utils/initial_chunk_schedule_target.py` |
+| `INITIAL_CHUNK_DAILY_QUOTA_POLICY` | `utils/campaign_send_policy.py` |
+| `_continue_initial_chunk_core`, `continue_initial_chunk` | `app.py` |
+| `summarize_initial_chunk_materialization_rows` | `utils/continue_initial_chunk_report.py` |
+| Rota admin stale recovery | `app.py` (lookup `_recover_stale_scheduled_initial_uazapi_sends`) |
+
+---
+
+*Documento produzido como análise estática do repositório; comportamento de produção pode depender de variáveis de ambiente não inspecionadas em runtime.*

--- a/docs/UAZAPI_SCHEDULE_MATERIALIZE_RESILIENCE_SPEC.md
+++ b/docs/UAZAPI_SCHEDULE_MATERIALIZE_RESILIENCE_SPEC.md
@@ -1,0 +1,219 @@
+# Especificação — refatoração: schedule, materialize e resiliência Uazapi
+
+**Status:** proposta de produto + engenharia (não implementada).  
+**Entrada obrigatória (QA / análise):** `docs/UAZAPI_SCHEDULE_CHUNKS_MATERIALIZE_EXPLORATORY.md` — gap analysis, fluxo atual, janela de materialize, e débito técnico (duplicação `app.py` / `worker_cadence`, ausência de taxonomia de erro no cliente Uazapi, `failed` sem `lead_ids` alocados, “dia seguinte” após slot matinal + `failed` não bloquear).
+
+---
+
+## 0. Problema e objetivos
+
+| Problema observado | O que a análise de QA atribui ao código de hoje |
+| --- | --- |
+| 500 com `No session` → utilizador sem aviso no produto | `create_advanced_campaign` devolve `None` para qualquer HTTP ≠ 200; materialize grava `failed` sem distinguir desconexão; não há notificação ao dono. |
+| Após chunk `failed` (sem folder), o próximo agendamento “parece” D+1 | `schedule_next_initial_chunk` usa slot matinal / `cadence_next_initial_send_slot`; `failed` não entra em `INITIAL_CHUNK_ACTIVE_SEND_STATUSES`, logo pode inserir nova linha no **próximo** slot canónico (sou muitas vezes manhã seguinte). `lead_ids` muitas vezes ainda `[]` no caminho de falha — risco de elegibilidade vs duplicação mal documentada. |
+
+**Objetivo da refatoração:** uma cadeia coerente **schedule → (pré-checagem) → create (API) → materialize → sync**, com:
+
+- estado persistido e inspeccionável;
+- retomada após falha **transiente** com backoff na **mesma janela de negócio** quando a política assim o exigir;
+- **sem** reenvio duplicado ao mesmo lead (alinhado a `lead_ids` + pastas Uazapi + sync);
+- **sem** abandono dos leads do chunk que falhou antes de pasta;
+- tratamento explícito de **desconexão** (utilizador avisado + campanha em estado controlado).
+
+**Fora de escopo (confirmado):** alterar o contrato da API Uazapi fora do cliente HTTP existente; redesign completo do admin (apenas estados / mensagens / hooks).
+
+---
+
+## 1. Decisões de produto (travadas nesta spec)
+
+### 1.1 Retentativa automática vs pausa após desconexão
+
+| Decisão | Escolha | Fundamento |
+| --- | --- | --- |
+| Após detetar instância **desconectada** (pré-checagem ou corpo `No session`) | **Pausa lógica da materialização** para essa instância/campanha: não chamar `create_advanced_campaign` em loop a cada 30s. | Evita carga na Uazapi e no worker; alinha com a realidade (reconexão é ação do utilizador). |
+| Retentativas **automáticas** | Aplicar só a erros classificados como **transientes** (rede, 502/503/504, timeout) **enquanto** a instância estiver **connected** (ou status desconhecido após 1 leitura). | Backoff com teto; não substitui reconexão. |
+| “Dia seguinte” | **Não** empurrar automaticamente para o próximo dia civil **só** porque houve um 5xx transiente na mesma janela; o **próximo** `scheduled_for` deve ser recalculado por uma **função única** (ver §4) com política: `retry_at` (backoff) vs `next_valid_brt` (janela) vs “slot diário canónico” (anti-flood). | Corrige a percepção de “saltou para amanhã” após falha evitável. |
+
+*Nota:* “Pausa lógica” pode mapear para `campaigns.status` auxiliar, coluna `materialization_block_reason`, ou tabela de fila; ver §3.1.
+
+### 1.2 Notificação (Parte A) — frequência máxima e idempotência
+
+| Regra | Valor sugerido (configurável) |
+| --- | --- |
+| Máximo de avisos **por (user_id, instance_id)** por incidente de desconexão | 1 notificação / 24h por defeito (env `SUPPORT_NOTIFY_DISCONNECT_COOLDOWN_HOURS` ou tabela `user_notification_cooldown`). |
+| Deduplicação | Chave: `hash(user_id, instance_id, 'uazapi_disconnected')` + janela temporal; persistir `last_notified_at` (ex.: em `instances` ou tabela `notification_log`). |
+| Opt-out | Env `SUPPORT_UAZAPI_NOTIFY_ENABLED=0` desliga avisos (só log + admin); opt-out por utilizador fica como P2 se necessário. |
+
+**Texto da mensagem (obrigatório, variáveis):**
+
+> `{nome}, sua instância de Whatsapp está desconectada. Acesse o *Leads Infinitos* e reconecte para garantir o funcionamento da sua automação.`
+
+- `{nome}`: display name do utilizador — **gap presente:** a tabela `users` no bootstrap de `app.py` hoje tem `email` + `password_hash` (sem coluna `name`); a implementação deve **adicionar** `display_name` (ou reutilizar email local antes de `@`) e, para WA, **número** de contacto (novo campo em `users` ou tabela de perfil). Até lá, fallback: e-mail transacional + log (ver §8).
+- Formatação `*negrito*` — confirmar se a API de envio (Uazapi `send_text`) suporta metadados WhatsApp; se não, enviar texto plano sem `*`.
+
+### 1.3 “Restart/reconnect” (limitação Uazapi)
+
+- **Spec técnica:** a rotina de **reconnect** no produto = **sinalizar ao utilizador** (notificação Parte A) + link para o fluxo já existente de QR/conexão no app (não supor `POST /instance/connect` em loop sem ação do utilizador, salvo alinhamento explícito com a documentação Uazapi e testes de segurança).
+- Opcional (flag): **uma** tentativa de `UazapiService.connect(token)` (instância avariada) apenas se o prod quiser “despertar” sessão — default **off**.
+
+---
+
+## 2. Parte A — Notificação e pré-checagem (engenharia)
+
+### 2.1 Granularidade e ordem
+
+| Momento | Ação | Motivo |
+| --- | --- | --- |
+| **A — Por tentativa** imediatamente **antes** de `create_advanced_campaign` (e opcionalmente antes de `POST` no mesmo tick para FU) | `get_status(token_campanha)` na instância do send | Rejeitar cedo; evita 500 e classifica desconexão. |
+| **B — Por tick (opcional / cache)** | Não invocar `get_status` para todas as instâncias a cada 30s sem cache; TTL em memória Redis **ou** “última leitura + 60s” por `instance_id` | NFR: rate limit à API Uazapi. |
+| Se `get_status` falhar (None / timeout) | Não notificar desconexão; tratar como “desconhecido” e deixar fluxo de erro transiente (ou 1 retry de status). | Evitar falso “disconnected”. |
+
+**Decisão:** o pré-checque **mínimo** exigido para esta spec é **por tentativa de materialize**; cache por tick é **recomendado** antes do volume subir.
+
+### 2.2 Aviso ao “número do cliente” via instância de suporte
+
+- **Token:** lido de variável de ambiente `SUPPORT_UAZAPI_INSTANCE_TOKEN` (nunca commitar o valor; inject no deploy).
+- **Destinatário:** número de WhatsApp do **dono** da campanha — provavelmente **não** existe no schema atual; a spec exige **migração** `users.phone_e164` (ou entidade `user_contact`) **ou** uso de telefone já guardado em outra tabela (a confirmar no desenho). Enquanto inexistente: notificação **não-WA** (e-mail) + banner in-app para cumprir o “utilizador avisado” de forma honesta.
+- **Envio:** `UazapiService.send_text(support_token, e164_destino, message)` (ou API equivalente já usada no projeto). Validar tamanho e JID.
+- **Segurança:** token de suporte só em segredo/secret manager; logs **sem** token; sem PII além do necessário em logs estruturados.
+
+### 2.3 NFR: logs e métricas
+
+Log estruturado (JSON) sugerido:
+
+- `event`: `uazapi_precheck`, `uazapi_disconnect_notify_skipped_cooldown`, `uazapi_disconnect_notify_sent`, `uazapi_materialize_blocked_disconnected`
+- `campaign_id`, `instance_id`, `user_id`, `send_id` (quando existir)
+- Nunca logar `apikey` / token.
+
+---
+
+## 3. Parte B — Estados, invariantes e sync de leads
+
+### 3.1 Máquina de estados alvo — `campaign_stage_sends` (etapa Uazapi com pasta)
+
+```mermaid
+stateDiagram-v2
+    [*] --> scheduled: schedule_next / continue API
+    scheduled --> materializing: entrou na janela de materialize
+    materializing --> running: create OK, folder_id persistido
+    materializing --> scheduled: falha transiente, backoff (mesmo lead_ids)
+    materializing --> waiting_reconnect: disconnected / No session
+    waiting_reconnect --> scheduled: instance connected again (retry)
+    scheduled --> failed: esgotou retries / terminal / política
+    running --> partial: envio Uazapi em andamento
+    running --> done: concluído + sync
+    partial --> done: concluído
+    running --> failed: cancel / irreversível (só com regra explícita)
+```
+
+**Notas:**
+
+- `materializing` pode ser **sub-estado** implementado com coluna `materialize_attempt_at` + `status=scheduled` **ou** valor de enum novo — decisão de schema em §5.
+- `waiting_reconnect` pode ser `campaigns.uazapi_materialize_paused` + `reason=disconnected` se preferir **uma** coluna a nível de campanha em vez de por linha.
+
+**Invariantes:**
+
+1. Se `uazapi_folder_id` IS NULL, não pode existir `status IN ('running','partial','done')` (exceto se definirem `running` sem folder legado; migração deve normalizar).
+2. Se `lead_ids` preenchido e sem folder, a linha está em **pré-API** (materializing ou scheduled com retry) — o SQL de **exclusão** de leads para novo chunk (ver análise QA) deve considerar **reserva** explícita (ver §3.2).
+
+### 3.2 Leads no chunk: modelo único pós-refatoração (proposta)
+
+| Conceito | Comportamento alvo | Relação com o gap atual |
+| --- | --- | --- |
+| **Reserva** | Ao alocar leads a um `send_id` **antes** de `create_advanced_campaign`, persistir `lead_ids` (e opcionalmente `reservation_status=pending_create`). | Hoje, em falha cedo, `lead_ids` pode continuar `[]` — a exclusão SQL de outros chunks pode **re-oferecer** o mesmo lead ou gerar condição de corrida. |
+| **Elegibilidade** | Leads em `reservation` para um send **falhado** sem folder tornam-se elegíveis **só** após `release` explícita (falha terminal) ou reassign para novo `send_id` na mesma campanha/etapa. | Garante “sem abandono” e “sem duplicar” alinhado a sync. |
+| **Já contabilizado na Uazapi** | Continuar a tratar `last_sent_folder_id` + sync (como hoje) como prova de envio; não realocar lead com envio confirmado. | Não regressão. |
+
+**Critério de aceite B3:** se um chunk falha **sem** folder, os leads alocados nesse send devem **aparecer** no próximo `schedule`/`materialize` (novo `send_id` ou retry na mesma linha conforme decisão) **sem** duplicar envio já em pasta anterior.
+
+### 3.3 Falhas transientes: política de `scheduled_for`
+
+- Classificar erros: `transient_network`, `transient_5xx`, `transient_no_session` (a última, na prática, vira **waiting_reconnect** após notificação — não D+1 automático).
+- `next_attempt_at_utc` = `now + backoff(attempt)` com teto (ex. máx. 1h para worker 30s → tentativas espalhadas N vezes, não spam).
+- **Não** substituir por `cadence_next_initial_send_slot` **apenas** por ter falhado; só usar slot matinal D+1 quando a política de **anti-flood** ou cota exigir (reuso da função única de §4).
+
+### 3.4 Fonte de verdade única (Parte B4)
+
+Extrair módulo compartilhado, por exemplo `utils/uazapi_chunk_schedule.py` (nome final livre), responsável por:
+
+- Dado: `campaign` (janela BRT, `scheduled_start`, cota, flags D1), `context` (retry vs primeiro chunk do dia), `now_utc`  
+- Devolver: `ScheduledDecision { scheduled_for_utc_naive, allow_insert, reason, policy_tag }`  
+- Consumidores: `worker_cadence.schedule_next_initial_chunk`, `app._continue_initial_chunk_core`, (opcional) `recover_stale` para bump coerente.
+
+**Eliminar divergência:** hoje o app usa `now+30s` ou `next_valid` com `MATERIALIZE_LOOKAHEAD_MIN`; o worker usa `initial_chunk_schedule_target` + `next_valid` com margem 0 — tudo passa a uma **única** política parametrizada.
+
+Janela de **materialize** (`LOOKAHEAD/LOOKBACK`) permanece NFR do worker, mas a **regra de negócio** “quando o próximo chunk pode existir” não depende de constantes espalhadas.
+
+---
+
+## 4. Sequência alvo (visão de runtime)
+
+```mermaid
+sequenceDiagram
+    participant W as worker_cadence
+    participant S as uazapi_schedule (SSOT)
+    participant P as precheck get_status
+    participant U as Uazapi API
+    participant N as support notify
+    W->>S: próximo slot / retry
+    S-->>W: scheduled_for, metadata
+    W->>P: get_status(instance)
+    alt disconnected
+        W->>N: notify (cooldown)
+        W-->>W: state waiting_reconnect or pause campaign
+    else ok / unknown
+        W->>U: create_advanced_campaign
+        alt 5xx/timeout
+            W-->>W: backoff, persist error class
+        else 200+folder
+            W-->>W: running, sync
+        end
+    end
+```
+
+---
+
+## 5. Plano de migração de dados
+
+1. **Inventário:** linhas `status='scheduled' AND uazapi_folder_id IS NULL` com `scheduled_for` muito no passado — já coberto por `UAZAPI_STALE_RECOVERY_TTL_MINUTES` (rever para alinhar com nova coluna de retry).
+2. **Normalização:** backfill de `last_materialize_error_code` nulo; mapear `failed` recents → `failed|retryable` só se houver log (opcional, pode ser forward-only).
+3. **Reserva de `lead_ids`:** migração pode **não** forçar backfill; a partir de versão N, **todo** materialize que escolhe leads grava `lead_ids` **antes** do `POST` (transação: lock de leads vs duplicata).
+4. **Compatibilidade:** manter `INITIAL_CHUNK_ACTIVE_SEND_STATUSES` sincronizado com o novo enum (ex.: adicionar `materializing` e `waiting_reconnect` se bloquearem o mesmo que `scheduled`).
+
+---
+
+## 6. Critérios de aceite mensuráveis (MVP desta spec)
+
+1. **Desconexão durante campanha:** utilizador recebe **no máximo 1** WhatsApp de suporte / 24h / instância (com cooldown) quando a desconexão for detetada no fluxo; log `uazapi_disconnect_notify_sent` ou `skipped` com motivo.
+2. **Pausa vs retry:** campanha/instância com desconexão **não** gera N chamadas a `create_advanced_campaign` com o mesmo padrão de failure; após reconexão (status connected), o worker retoma (transição `waiting_reconnect` → `scheduled`/`materializing`).
+3. **Chunk sem folder após alocação:** leads do chunk **não** saem do conjunto de pendentes sem decisão; próximo sucesso **não** reenvia para o mesmo lead que já consta como enviado noutra pasta (invariantes de sync atuais preservados).
+4. **Não regressão:** `sync_campaign_leads_from_uazapi`, listfolders, contadores e admin (visão mínima de estado/reason) permanecem coerentes; testes existentes de `test_sync_uazapi.py` / `test_worker_*` ajustados.
+
+---
+
+## 7. Testes (além do documento de QA)
+
+- **Unit:** classificador de erros a partir de `response` JSON (`No session`) e status HTTP, sem chamar rede.
+- **Unit:** `ScheduledDecision` — mesmo input → mesmo output para worker e app.
+- **Integração (opcional):** mock Uazapi: sequência get_status → disconnected → notify 1x → get_status → connected → create success.
+- **Carga:** com cooldown, garantir N ticks não geram N `send_text` de suporte.
+
+---
+
+## 8. Dependências e riscos
+
+- **Dependência directa do QA:** análise em `docs/UAZAPI_SCHEDULE_CHUNKS_MATERIALIZE_EXPLORATORY.md` (gaps C, E, débito duplicação, janela UTC 15+5 min).
+- **Número do utilizador:** se o produto ainda não tiver telemóvel obrigatório, a Parte A precisa de **fallback** (e-mail + banner in-app) para cumprir o “utilizador avisado” na aceite 1.
+- **Token de suporte:** operação (deploy) deve fornecer `SUPPORT_UAZAPI_INSTANCE_TOKEN`; risco de ambiente de staging sem token — deflag `SUPPORT_UAZAPI_NOTIFY_ENABLED`.
+
+---
+
+## 9. Changelog
+
+| Data | Nota |
+| --- | --- |
+| 2026-04-29 | Versão inicial da spec, alinhada à análise de QA e requisitos de negócio. |
+
+---
+
+*Texto aprovado para início de desenho técnico (tasks) e estimativa; ajustar decisões 1.1/1.2 com PM se “pausa lógica” tiver de refletir-se no Kanban (UI mínima).*


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary
Adds a product and engineering specification for refactoring Uazapi schedule / materialize / resilience, building on `docs/UAZAPI_SCHEDULE_CHUNKS_MATERIALIZE_EXPLORATORY.md` (QA analysis).

## Contents
- Part A: pre-check (`get_status`), support notification via `SUPPORT_UAZAPI_INSTANCE_TOKEN`, cooldown/idempotency, rate limits, structured logs
- Part B: target state machine, lead reservation before `create_advanced_campaign`, single SSOT for scheduling (`utils/uazapi_chunk_schedule` proposal), migration notes
- Explicit decisions: pause on disconnect vs transient retry; when D+1 applies; accept criteria
- Notes: current `users` table has no phone/name in bootstrap; migration or non-WA fallback required

## File
- `docs/UAZAPI_SCHEDULE_MATERIALIZE_RESILIENCE_SPEC.md`
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-fa4cab12-2ad0-422e-9403-7d54f89613b6"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-fa4cab12-2ad0-422e-9403-7d54f89613b6"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

