### PR TITLE
feat(uazapi): resiliência materialize, no_session, notificação

### DIFF
--- a/app.py
+++ b/app.py
@@ -3304,7 +3304,8 @@ def admin_campaigns():
     return render_template('admin/campaigns.html',
                          campaigns=campaigns,
                          status_filter=status_filter,
-                         counts=counts)
+                         counts=counts,
+                         csrf_token=session.get('csrf_token', ''))
 
 
 @app.route('/api/admin/campaigns/<int:campaign_id>/detail', methods=['GET'])
@@ -4077,6 +4078,152 @@ def admin_flush_stale_initial_chunk(campaign_id):
         return jsonify({"error": "server_error", "message": str(e)}), 500
     finally:
         conn.close()
+
+
+def _uazapi_instance_status_summary(payload):
+    """Retorna (label, code) para a UI: connected|disconnected|unknown."""
+    if not payload or not isinstance(payload, dict):
+        return "unknown", None
+    inst = payload.get("instance")
+    if isinstance(inst, dict):
+        st = (inst.get("status") or inst.get("state") or "").lower()
+    else:
+        st = (payload.get("status") or payload.get("state") or "").lower()
+    if st in ("disconnected", "close", "closed", "logout", "offline"):
+        return "disconnected", st or None
+    if st in ("connected", "open", "ready", "synchronized"):
+        return "connected", st or None
+    if st in ("connecting",):
+        return "connecting", st or None
+    return "unknown", st or None
+
+
+@app.route("/api/admin/campaigns/force-initial-chunk", methods=["POST"])
+@login_required
+@admin_required
+def admin_force_initial_chunk():
+    """
+    Admin: verifica get_status das instâncias Uazapi vinculadas e chama
+    ``_continue_initial_chunk_core`` (cancel_scheduled opcional) para forçar novo chunk
+    com leads pendentes ainda sem envio na etapa inicial.
+    """
+    csrf_err = _verify_json_csrf()
+    if csrf_err:
+        return csrf_err
+    data = request.get_json(silent=True) or {}
+    try:
+        campaign_id = int(data.get("campaign_id") or 0)
+    except (TypeError, ValueError):
+        campaign_id = 0
+    if campaign_id < 1:
+        return (
+            jsonify(
+                {
+                    "ok": False,
+                    "error": "invalid_campaign_id",
+                    "message": "Informe o ID numérico da campanha.",
+                }
+            ),
+            400,
+        )
+    cancel_scheduled = data.get("cancel_scheduled", True) is not False
+    confirm_name = (data.get("confirm_name") or "").strip()
+
+    conn = get_db_connection()
+    try:
+        with conn.cursor(cursor_factory=RealDictCursor) as cur:
+            cur.execute(
+                "SELECT c.id, c.name, c.user_id FROM campaigns c WHERE c.id = %s",
+                (campaign_id,),
+            )
+            camp_row = cur.fetchone()
+    finally:
+        conn.close()
+
+    if not camp_row:
+        return (
+            jsonify(
+                {
+                    "ok": False,
+                    "error": "not_found",
+                    "message": "Campanha não encontrada.",
+                }
+            ),
+            404,
+        )
+    if confirm_name and (camp_row.get("name") or "").strip() != confirm_name:
+        return (
+            jsonify(
+                {
+                    "ok": False,
+                    "error": "name_mismatch",
+                    "message": "O nome completo da campanha não confere (confirmação de segurança).",
+                }
+            ),
+            400,
+        )
+
+    uazapi = UazapiService()
+    instance_checks = []
+    conn2 = get_db_connection()
+    try:
+        with conn2.cursor(cursor_factory=RealDictCursor) as cur:
+            cur.execute(
+                """
+                SELECT i.id AS instance_id, i.name AS instance_name, i.apikey
+                FROM campaign_instances ci
+                JOIN instances i ON i.id = ci.instance_id
+                WHERE ci.campaign_id = %s
+                  AND COALESCE(i.api_provider, 'megaapi') = 'uazapi'
+                  AND i.apikey IS NOT NULL
+                ORDER BY i.id ASC
+                """,
+                (campaign_id,),
+            )
+            insts = cur.fetchall() or []
+    finally:
+        conn2.close()
+    for ins in insts:
+        token = (ins.get("apikey") or "").strip()
+        st_payload = uazapi.get_status(token) if token else None
+        label, code = _uazapi_instance_status_summary(st_payload)
+        instance_checks.append(
+            {
+                "instance_id": ins.get("instance_id"),
+                "instance_name": ins.get("instance_name"),
+                "connection": label,
+                "status_code": code,
+            }
+        )
+
+    owner_id = int(camp_row["user_id"])
+    r = _continue_initial_chunk_core(
+        campaign_id,
+        owner_id,
+        log_label="admin-force-initial-chunk",
+        cancel_scheduled=cancel_scheduled,
+    )
+    body = r.get("body") or {}
+    ok = bool(r.get("ok"))
+    sc = int(r.get("status_code") or 500)
+    print(
+        f"[admin-force-initial-chunk] campaign_id={campaign_id} admin_user={current_user.id} "
+        f"ok={ok} http={sc} cancel_scheduled={cancel_scheduled} result_keys={list(body.keys()) if isinstance(body, dict) else 'n/a'}"
+    )
+    return (
+        jsonify(
+            {
+                "ok": ok,
+                "status_code": sc,
+                "campaign_id": campaign_id,
+                "campaign_name": camp_row.get("name"),
+                "cancel_scheduled": cancel_scheduled,
+                "instance_status": instance_checks,
+                "result": body,
+            }
+        ),
+        sc,
+    )
 
 
 @app.route('/api/admin/campaigns/<int:campaign_id>/leads', methods=['GET'])

--- a/app.py
+++ b/app.py
@@ -6527,6 +6527,331 @@ def _initial_chunk_materialization_outcomes(created_ids):
     return summarize_initial_chunk_materialization_rows([dict(r) for r in rows])
 
 
+def _force_uazapi_initial_chunk_no_cadence(
+    campaign_id, user_id, log_label, cancel_scheduled, campaign
+):
+    """
+    Uazapi sem cadência: cria pastas via create_advanced_campaign como no fluxo de criação
+    de campanha (sem `campaign_stage_sends` scheduled + worker). Usado por admin e API
+    ``continue-initial-chunk`` quando ``enable_cadence`` é falso.
+    """
+    from utils.campaign_send_policy import (
+        INITIAL_CHUNK_DAILY_QUOTA_POLICY,
+        uazapi_initial_chunk_distribution_limits,
+    )
+    from utils.limits import can_create_campaign_today, check_initial_chunk_daily_quota_for_campaign
+    from utils.sync_uazapi import _normalize_phone_for_api
+    from utils.uazapi_pacing import default_inter_message_delay_range_minutes
+
+    conn = get_db_connection()
+    with conn.cursor(cursor_factory=RealDictCursor) as cur:
+        cur.execute(
+            """
+            SELECT COUNT(*) AS cnt FROM campaign_leads
+            WHERE campaign_id = %s
+              AND status = 'pending'
+              AND current_step = 1
+              AND COALESCE(removed_from_funnel, FALSE) = FALSE
+              AND COALESCE(cadence_status, 'active') NOT IN ('converted', 'lost')
+            """,
+            (campaign_id,),
+        )
+        row = cur.fetchone()
+    conn.close()
+    pending_count = int(row.get("cnt") or 0) if row else 0
+    if pending_count <= 0:
+        return {
+            "ok": False,
+            "status_code": 400,
+            "body": {
+                "error": "Nenhum lead pendente para enviar nesta etapa",
+                "code": "no_pending_leads",
+            },
+        }
+
+    instances = _get_uazapi_instances_for_campaign(campaign_id, user_id)
+    if not instances:
+        return {
+            "ok": False,
+            "status_code": 400,
+            "body": {"error": "Nenhuma instância Uazapi vinculada"},
+        }
+
+    if not check_initial_chunk_daily_quota_for_campaign(campaign_id):
+        return {
+            "ok": False,
+            "status_code": 429,
+            "body": {
+                "error": "Limite diário de envios iniciais atingido para hoje (BRT).",
+                "code": "initial_chunk_daily_quota_exceeded",
+                "quota_policy": INITIAL_CHUNK_DAILY_QUOTA_POLICY,
+            },
+        }
+
+    allowed = list(instances)
+    if cancel_scheduled:
+        conn = get_db_connection()
+        with conn.cursor() as cur:
+            cur.execute(
+                """
+                UPDATE campaign_stage_sends SET status = 'failed', updated_at = NOW()
+                WHERE campaign_id = %s AND stage = 'initial' AND status IN ('scheduled', 'waiting_reconnect')
+                """,
+                (campaign_id,),
+            )
+            n_cancel = cur.rowcount
+        conn.commit()
+        conn.close()
+        if n_cancel:
+            print(
+                f"[UAZAPI] {log_label} (no_cadence) campaign_id={campaign_id}: "
+                f"cancelados {n_cancel} chunk(s) scheduled/waiting_reconnect"
+            )
+
+    conn_busy = get_db_connection()
+    with conn_busy.cursor(cursor_factory=RealDictCursor) as cur:
+        cur.execute(
+            """
+            SELECT instance_id FROM campaign_stage_sends
+            WHERE campaign_id = %s AND stage = 'initial'
+              AND instance_id = ANY(%s)
+              AND status = ANY(%s)
+            """,
+            (
+                campaign_id,
+                [i["instance_id"] for i in allowed],
+                list(INITIAL_CHUNK_ACTIVE_SEND_STATUSES),
+            ),
+        )
+        busy = {r["instance_id"] for r in (cur.fetchall() or [])}
+    conn_busy.close()
+    allowed = [i for i in allowed if i["instance_id"] not in busy]
+    if not allowed:
+        return {
+            "ok": False,
+            "status_code": 409,
+            "body": {
+                "error": "Já existe chunk em andamento para esta instância. Aguarde conclusão ou falha.",
+            },
+        }
+
+    daily_limit = int(campaign.get("daily_limit") or 0)
+    if daily_limit <= 0:
+        daily_limit = int(
+            get_user_daily_limit(user_id) or 30
+        )
+    n_inst = len(allowed)
+    per_instance_limit, total_limit = uazapi_initial_chunk_distribution_limits(
+        daily_limit, n_inst
+    )
+
+    msg_raw = campaign.get("message_template") or ""
+    try:
+        variations = json.loads(msg_raw) if str(msg_raw).strip() else []
+        if isinstance(variations, str):
+            variations = [variations]
+        if not variations:
+            variations = ["Olá!"]
+    except Exception:
+        variations = [str(msg_raw).strip() or "Olá!"]
+
+    conn = get_db_connection()
+    with conn.cursor(cursor_factory=RealDictCursor) as cur:
+        cur.execute(
+            """SELECT id, phone, whatsapp_link, name FROM campaign_leads
+               WHERE campaign_id = %s AND status = 'pending'
+               ORDER BY COALESCE(send_batch, 999) ASC, id ASC LIMIT %s""",
+            (campaign_id, total_limit),
+        )
+        leads = cur.fetchall() or []
+    conn.close()
+
+    def _chunk(lst, n):
+        return [lst[i : i + n] for i in range(0, len(lst), n)]
+
+    lead_chunks = _chunk(list(leads), per_instance_limit)
+
+    d_lo, d_hi = default_inter_message_delay_range_minutes()
+    if campaign.get("delay_min_minutes") is not None:
+        try:
+            d_lo = int(campaign.get("delay_min_minutes"))
+        except (TypeError, ValueError):
+            pass
+    if campaign.get("delay_max_minutes") is not None:
+        try:
+            d_hi = int(campaign.get("delay_max_minutes"))
+        except (TypeError, ValueError):
+            pass
+    if d_hi < d_lo:
+        d_hi = d_lo
+    delay_min_sec = int(d_lo * 60)
+    delay_max_sec = int(d_hi * 60)
+
+    scheduled_for_param = None
+    sched_raw = campaign.get("scheduled_start")
+    if sched_raw:
+        try:
+            dt = datetime.fromisoformat(str(sched_raw).replace("Z", "+00:00"))
+            now = datetime.now(dt.tzinfo) if dt.tzinfo else datetime.now()
+            delta_min = (dt - now).total_seconds() / 60
+            if delta_min > 0:
+                scheduled_for_param = max(1, int(delta_min))
+        except Exception:
+            pass
+
+    uazapi = UazapiService()
+    name = (campaign.get("name") or "")[:200]
+    sends_created = []
+    errors = []
+    for idx, chunk in enumerate(lead_chunks):
+        if idx >= len(allowed):
+            break
+        inst = allowed[idx]
+        if not can_create_campaign_today(inst["instance_id"]):
+            errors.append(
+                f"Instância {inst['instance_id']}: can_create_campaign_today bloqueou (limite legado)"
+            )
+            continue
+        token = (inst.get("apikey") or "").strip()
+        if not token:
+            errors.append(f"Instância {inst['instance_id']}: sem token")
+            continue
+        messages = []
+        lead_ids = []
+        for lead in chunk:
+            msg_text = random.choice(variations)
+            if lead.get("name"):
+                msg_text = (
+                    msg_text.replace("{nome}", lead["name"])
+                    .replace("{name}", lead["name"])
+                    .replace("{{nome}}", lead["name"])
+                    .replace("{{name}}", lead["name"])
+                )
+            raw = lead.get("phone") or lead.get("whatsapp_link")
+            phone = _normalize_phone_for_api(raw)
+            if not phone:
+                continue
+            messages.append({"number": phone, "type": "text", "text": msg_text})
+            lead_ids.append(lead["id"])
+        if not messages:
+            if chunk:
+                errors.append(
+                    f"Instância {inst['instance_id']}: chunk sem telefone válido (todos os números inválidos?)"
+                )
+            continue
+        print(
+            f"[UAZAPI] {log_label} no_cadence create_advanced_campaign campaign_id={campaign_id} inst={inst['instance_id']} n={len(messages)}"
+        )
+        result = uazapi.create_advanced_campaign(
+            token,
+            delay_min_sec,
+            delay_max_sec,
+            messages,
+            info=name or f"Campaign {campaign_id}",
+            scheduled_for=scheduled_for_param,
+        )
+        folder_id = None
+        if isinstance(result, dict):
+            folder_id = result.get("folder_id") or result.get("folderId")
+        if folder_id:
+            instance_remote_jid = _resolve_uazapi_remote_jid(uazapi, token)
+            sends_created.append(
+                {
+                    "instance_id": inst["instance_id"],
+                    "instance_remote_jid": instance_remote_jid,
+                    "folder_id": folder_id,
+                    "lead_ids": lead_ids,
+                    "planned_count": len(lead_ids),
+                }
+            )
+        else:
+            err_h = (result or {}).get("error") if isinstance(result, dict) else None
+            err_m = (result or {}).get("message") if isinstance(result, dict) else None
+            if isinstance(result, dict) and result.get("uazapi_request_failed"):
+                err_h = (result.get("error_body") or result.get("exception") or err_h) or err_h
+            err_txt = f"Instância {inst['instance_id']}: falha ao criar campanha"
+            if err_h or err_m:
+                err_txt += f" — {err_h or err_m}"
+            errors.append(err_txt[:2000])
+
+    if sends_created:
+        all_lead_ids = [lid for s in sends_created for lid in s["lead_ids"]]
+        first_folder_id = sends_created[0]["folder_id"]
+        conn = get_db_connection()
+        with conn.cursor(cursor_factory=RealDictCursor) as cur:
+            for send in sends_created:
+                cur.execute(
+                    "INSERT INTO uazapi_instance_sends (instance_id, campaign_id) VALUES (%s, %s)",
+                    (send["instance_id"], campaign_id),
+                )
+                cur.execute(
+                    """INSERT INTO campaign_stage_sends
+                       (campaign_id, stage, instance_id, instance_remote_jid, uazapi_folder_id, status, planned_count, lead_ids)
+                       VALUES (%s, 'initial', %s, %s, %s, 'running', %s, %s)""",
+                    (
+                        campaign_id,
+                        send["instance_id"],
+                        send.get("instance_remote_jid"),
+                        send["folder_id"],
+                        send["planned_count"],
+                        json.dumps(send["lead_ids"]),
+                    ),
+                )
+            cur.execute(
+                "UPDATE campaigns SET uazapi_folder_id = %s, uazapi_last_send_lead_ids = %s, status = 'running' WHERE id = %s",
+                (
+                    first_folder_id,
+                    json.dumps(all_lead_ids) if all_lead_ids else None,
+                    campaign_id,
+                ),
+            )
+            cur.execute(
+                "UPDATE campaign_leads SET current_step = 1 WHERE campaign_id = %s AND id = ANY(%s)",
+                (campaign_id, all_lead_ids),
+            )
+        conn.commit()
+        conn.close()
+
+    if sends_created and errors:
+        return {
+            "ok": True,
+            "status_code": 207,
+            "body": {
+                "success": True,
+                "partial": True,
+                "message": f"Criada(s) {len(sends_created)} pasta(s); com avisos: " + "; ".join(errors),
+                "mode": "uazapi_no_cadence",
+                "errors": errors,
+                "sends_created": len(sends_created),
+            },
+        }
+    if sends_created:
+        return {
+            "ok": True,
+            "status_code": 200,
+            "body": {
+                "success": True,
+                "message": f"{len(sends_created)} sub-campanha(s) Uazapi criada(s) (sem cadência).",
+                "mode": "uazapi_no_cadence",
+                "sends_created": len(sends_created),
+            },
+        }
+    err_body = {
+        "error": "Não foi possível criar nenhuma pasta na Uazapi.",
+        "code": "uazapi_create_all_failed",
+        "mode": "uazapi_no_cadence",
+    }
+    if errors:
+        err_body["errors"] = errors
+    elif leads and not sends_created:
+        err_body["error"] = "Nenhum telefone válido para montar mensagens no chunk (verifique os leads)."
+    return {
+        "ok": False,
+        "status_code": 502,
+        "body": err_body,
+    }
+
+
 def _continue_initial_chunk_core(campaign_id, user_id, log_label="continue-initial-chunk", cancel_scheduled=False):
     """
     Agenda campaign_stage_sends (initial) e materializa na hora via worker_cadence (force_send_ids).
@@ -6541,8 +6866,9 @@ def _continue_initial_chunk_core(campaign_id, user_id, log_label="continue-initi
         conn = get_db_connection()
         with conn.cursor(cursor_factory=RealDictCursor) as cur:
             cur.execute(
-                """SELECT c.id, c.name, c.use_uazapi_sender, c.enable_cadence, c.delay_min_minutes, c.delay_max_minutes,
-                          c.daily_limit, c.send_hour_start, c.send_hour_end, c.send_saturday, c.send_sunday
+                """SELECT c.id, c.name, c.message_template, c.use_uazapi_sender, c.enable_cadence,
+                          c.delay_min_minutes, c.delay_max_minutes, c.daily_limit,
+                          c.send_hour_start, c.send_hour_end, c.send_saturday, c.send_sunday, c.scheduled_start
                    FROM campaigns c
                    WHERE c.id = %s AND c.user_id = %s""",
                 (campaign_id, user_id),
@@ -6554,7 +6880,9 @@ def _continue_initial_chunk_core(campaign_id, user_id, log_label="continue-initi
         if not campaign.get("use_uazapi_sender"):
             return {"ok": False, "status_code": 400, "body": {"error": "Campanha não usa Uazapi"}}
         if not campaign.get("enable_cadence"):
-            return {"ok": False, "status_code": 400, "body": {"error": "Campanha sem cadência habilitada"}}
+            return _force_uazapi_initial_chunk_no_cadence(
+                campaign_id, user_id, log_label, cancel_scheduled, campaign
+            )
 
         conn = get_db_connection()
         with conn.cursor(cursor_factory=RealDictCursor) as cur:

--- a/app.py
+++ b/app.py
@@ -239,6 +239,16 @@ def _init_db_body() -> None:
             );
             """
         )
+        cur.execute(
+            """
+            ALTER TABLE users ADD COLUMN IF NOT EXISTS display_name TEXT;
+            """
+        )
+        cur.execute(
+            """
+            ALTER TABLE users ADD COLUMN IF NOT EXISTS phone_e164 TEXT;
+            """
+        )
     
         # Adicionar coluna is_admin se não existir (migração)
         print("➡️ Adicionando coluna is_admin se necessário...")
@@ -426,6 +436,11 @@ def _init_db_body() -> None:
                 status TEXT DEFAULT 'disconnected',
                 updated_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP
             );
+            """
+        )
+        cur.execute(
+            """
+            ALTER TABLE instances ADD COLUMN IF NOT EXISTS last_disconnect_notify_at TIMESTAMPTZ;
             """
         )
 
@@ -718,6 +733,8 @@ def _init_db_body() -> None:
             ALTER TABLE campaign_stage_sends ADD COLUMN IF NOT EXISTS delay_max_minutes INTEGER;
             ALTER TABLE campaign_stage_sends ADD COLUMN IF NOT EXISTS message_variations JSONB;
             ALTER TABLE campaign_stage_sends ADD COLUMN IF NOT EXISTS fu_rollover_done BOOLEAN DEFAULT FALSE;
+            ALTER TABLE campaign_stage_sends ADD COLUMN IF NOT EXISTS last_materialize_error TEXT;
+            ALTER TABLE campaign_stage_sends ADD COLUMN IF NOT EXISTS materialize_attempt_count INTEGER DEFAULT 0;
             CREATE INDEX IF NOT EXISTS idx_campaign_stage_sends_campaign_stage
                 ON campaign_stage_sends(campaign_id, stage);
             CREATE INDEX IF NOT EXISTS idx_campaign_stage_sends_folder_id
@@ -2922,7 +2939,7 @@ def campaign_kanban_data(campaign_id):
                 with conn_sync.cursor(cursor_factory=RealDictCursor) as cur:
                     cur.execute(
                         """SELECT 1 FROM campaign_stage_sends
-                           WHERE campaign_id = %s AND status IN ('scheduled', 'running', 'partial')
+                           WHERE campaign_id = %s AND status IN ('scheduled', 'waiting_reconnect', 'running', 'partial')
                            LIMIT 1""",
                         (campaign_id,),
                     )
@@ -6114,7 +6131,7 @@ def get_campaign_stats(campaign_id):
             if campaign.get('use_uazapi_sender') and campaign.get('enable_cadence'):
                 with conn_stage.cursor() as cur_sched:
                     cur_sched.execute(
-                        "SELECT 1 FROM campaign_stage_sends WHERE campaign_id = %s AND stage = 'initial' AND status = 'scheduled' LIMIT 1",
+                        "SELECT 1 FROM campaign_stage_sends WHERE campaign_id = %s AND stage = 'initial' AND status IN ('scheduled', 'waiting_reconnect') LIMIT 1",
                         (campaign_id,),
                     )
                     has_scheduled_chunk = cur_sched.fetchone() is not None
@@ -6443,7 +6460,7 @@ def _continue_initial_chunk_core(campaign_id, user_id, log_label="continue-initi
                 cur.execute(
                     """
                     UPDATE campaign_stage_sends SET status = 'failed', updated_at = NOW()
-                    WHERE campaign_id = %s AND stage = 'initial' AND status = 'scheduled'
+                    WHERE campaign_id = %s AND stage = 'initial' AND status IN ('scheduled', 'waiting_reconnect')
                     """,
                     (campaign_id,),
                 )

--- a/docs/UAZAPI_SCHEDULE_CHUNKS_MATERIALIZE_EXPLORATORY.md
+++ b/docs/UAZAPI_SCHEDULE_CHUNKS_MATERIALIZE_EXPLORATORY.md
@@ -1,0 +1,208 @@
+# Uazapi — análise exploratória: schedule, chunks e materialização
+
+Documento de mapeamento do **comportamento atual** do código (sem refatoração), alinhado ao pedido de análise de `campaign_stage_sends`, `worker_cadence`, sync Uazapi e `create_advanced_campaign`.
+
+---
+
+## 1. Mapa do fluxo end-to-end
+
+### 1.1 Visão resumida (ordem de execução no worker)
+
+O loop principal é `process_cadence` em `worker_cadence.py`.
+
+```mermaid
+flowchart TD
+  A[process_cadence] --> B[_recover_stale_scheduled_initial_uazapi_sends]
+  B --> C[_materialize_scheduled_stage_sends]
+  C --> D[_process_verify_folder_queue]
+  D --> E{STAGE_SYNC_INTERVAL?}
+  E -->|~10 min| F[_sync_active_stage_folders]
+  E -->|senão skip| G[check_monitoring_leads]
+  F --> G
+  G --> H[process_uazapi_initial_stage_rollovers]
+  H --> I[Para cada campanha: schedule_next_initial_chunk OU process_rollover]
+  I --> J[enable_cadence: FU chain + process_campaign_sends]
+```
+
+### 1.2 Onde o próximo chunk é agendado (`scheduled_for`, BRT, cota)
+
+| Peça | Arquivo / função | Papel |
+| --- | --- | --- |
+| Slot “matinal” e mesmo dia (D1) | `utils/initial_chunk_schedule_target.py` — `cadence_next_initial_send_slot`, `resolve_initial_chunk_schedule_target`, `uazapi_same_day_initial_chunk_after_unlock_enabled` | Define o instante alvo (BRT) **antes** do `INSERT` em `campaign_stage_sends`. O env `UAZAPI_SAME_DAY_INITIAL_CHUNK_AFTER_UNLOCK` permite chunk no mesmo dia após o horário de início, se janela BRT + cota permitirem. |
+| Normalização para UTC naive + janela válida | `utils/next_valid_uazapi_send.py` — `next_valid_send_utc_naive` (usada em `schedule_next_initial_chunk` e em stale recovery) | Garante que o `scheduled_for` gravado cai numa janela de envio da campanha. |
+| Cota diária (TD-12 / G2 default) | `utils/limits.py` — `check_initial_chunk_daily_quota_for_campaign`; `utils/campaign_send_policy.py` — `INITIAL_CHUNK_DAILY_QUOTA_POLICY`, `initial_chunk_daily_quota_allows` | `schedule_next_initial_chunk` e `_recover_stale_scheduled_initial_uazapi_sends` consultam a cota; **inserção automática** do próximo chunk usa a cota no ramo D1. API `continue-initial-chunk` em `app.py` também bloqueia com **429** se a cota não permitir. |
+| “Chunk ativo” bloqueia duplicar na mesma instância | `utils/limits.py` — `INITIAL_CHUNK_ACTIVE_SEND_STATUSES` = `scheduled`, `running`, `partial`, `queued` | `schedule_next_initial_chunk` e `_continue_initial_chunk_core` (app) só inserem nova linha se **não** houver send nesse conjunto de status para `(campaign_id, stage, instance_id)`. `failed` / `done` **não** bloqueiam. |
+| Janela BRT no momento de materializar (não no INSERT) | `worker_cadence.py` — `_materialize_scheduled_stage_sends` + `is_campaign_send_window` / `next_valid_send_utc_naive` (margem `MATERIALIZE_LOOKAHEAD_MIN`) | Se na hora do materialize estiver fora da janela: **bump** de `scheduled_for` para o próximo `next_valid` **ou** `status = failed` se a janela for inválida. |
+
+**Nota importante:** `can_create_campaign_today` em `utils/limits.py` **sempre retorna `True`**; comentário explícito de que o limite antigo por instância/dia foi removido. O gate de volume “real” é a política TD-12 + `daily_limit` da campanha, não esse helper (ainda referenciado em comentários em `initial_chunk_schedule_target.py`).
+
+### 1.3 Janela de materialize automático (UTC)
+
+Definida em `worker_cadence.py` (cabeçalho e docstring de `_materialize_scheduled_stage_sends`):
+
+- `MATERIALIZE_LOOKBACK_MIN` = 15
+- `MATERIALIZE_LOOKAHEAD_MIN` = 5
+
+A query SQL (modo automático) filtra `campaign_stage_sends` com `status = 'scheduled'`, `uazapi_folder_id` NULL, `scheduled_for` entre `now_utc - lookback` e `now_utc + lookahead`. O loop Python aplica o mesmo corte em `remaining` (segundos) para evitar drift entre SQL e processamento.
+
+**Efeito prático:** se um `scheduled_for` cair fora da janela (ex.: atraso > 15 min sem tick), a linha **não** é materializada pelo worker nesse passo; entra o fluxo de **stale recovery** (abaixo).
+
+### 1.4 Onde `create_advanced_campaign` roda, persistência de `uazapi_folder_id`
+
+- **Serviço HTTP:** `services/uazapi.py` — `UazapiService.create_advanced_campaign` → `POST /sender/advanced` (`timeout=30`); em erro HTTP ou exceção de transporte retorna **`None`** (não levanta para o worker).
+- **Gravação na linha do chunk:** `worker_cadence.py` — `_materialize_scheduled_stage_sends`, após sucesso: `UPDATE campaign_stage_sends` com `uazapi_folder_id`, `instance_remote_jid`, `lead_ids`, `planned_count`, `status = 'running'`, etc.; e `INSERT INTO uazapi_instance_sends` para estatística por instância/dia.
+- **Pós-API “queued/scheduled”:** se `result.status` ∈ `queued`, `scheduled`, chama `edit_campaign(..., "continue")` para despertar o envio.
+- **Rolos FU / legacy:** `process_uazapi_initial_stage_rollovers`, `process_rollover`, `process_rollover_fu_next` também chamam `create_advanced_campaign` com contexto FU1/FU2/breakup.
+
+### 1.5 Falha de materialize: estado da linha e `lead_ids`
+
+Cenário `_materialize_scheduled_stage_sends` após chamar a API (resumo):
+
+| Situação | Efeito na linha `campaign_stage_sends` | `lead_ids` |
+| --- | --- | --- |
+| `create_advanced_campaign` retorna vazio/sem `folder_id` (ex.: 500, timeout, 401 — em todos os casos `UazapiService` devolve `None`) | `status = 'failed'` (UPDATE por `send_id`) | **Não** preenchido neste caminho; permanece o que estava (muitas vezes `[]` do INSERT inicial) |
+| 0 leads elegíveis (mesmo `scheduled_for` / etapa) | `UPDATE` em massa: `status = 'failed'` para o grupo `(campaign_id, stage, scheduled_for)` | Inalterado |
+| `chunk` vazio para uma instância (índice) | `status = 'done'`, `planned_count = 0` | Inalterado |
+| Sem mensagens step | `status = 'failed'` | Inalterado |
+| Sem `apikey` | `status = 'failed'` | Inalterado |
+| Fora da janela BRT (sem `ValueError` no `next_valid`) | `scheduled_for` = próximo `next_valid` (bump) | Inalterado até o materialize bem-sucedido gravar `lead_ids` |
+| Fora da janela BRT e janela de campanha inválida | `status = 'failed'` | Inalterado |
+| `can_create_campaign_today` falso | **Código:** `can_create_campaign_today` é sempre `True` — ramo inalcançável no estado atual, salvo mudança futura em `limits.py` | — |
+
+O **break** após falha no primeiro segmento de pacing interrompe o laço de segmentos para aquele `send_id` (comportamento documentado no código: falha cedo).
+
+### 1.6 Pré-sync antes de novo folder (Task 6)
+
+- `utils/sync_uazapi.py` — `sync_campaign_stage_sends_before_new_chunk`  
+  Condição: env `UAZAPI_RECONCILE_FIND_BEFORE_CHUNK` default `1`; exige `campaign` com send prévio **com** `uazapi_folder_id` na etapa. Chama `sync_campaign_leads_from_uazapi` com `campaigns.uazapi_folder_id` (primeira instância com apikey) para reconciliar antes de outro `create_advanced_campaign`.
+
+- Chamado de: `_materialize_scheduled_stage_sends` (por grupo de campanha/etapa), `schedule_next_initial_chunk`, e caminhos em `app.py` documentados (ex. FU imediato).
+
+Falha no pré-sync: em `_materialize` faz `rollback` e log `uazapi_materialize_pre_sync_failed` — o fluxo de materialize **continua** (não retorna cedo em todos os trechos; ver logs).
+
+### 1.7 Sync periódico, rollover e contadores de chunk
+
+- **`_sync_active_stage_folders` (`worker_cadence.py`)**  
+  A cada `STAGE_SYNC_INTERVAL_MINUTES` (10), para sends com `status IN ('scheduled','running','partial')` e `uazapi_folder_id` não nulo e `last_sync_at` antigo, chama `sync_campaign_leads_from_uazapi` na pasta da **campanha** (`campaigns.uazapi_folder_id`).
+
+- **Fonte de verdade agregada:** comentários em `utils/sync_uazapi.py` e `worker_cadence.py` — `GET /sender/listfolders` (`log_sucess`, `log_failed`, `log_total`, status da pasta). `listmessages` não substitui totais oficiais.
+
+- **`process_uazapi_initial_stage_rollovers`:** considera sends `initial` com `status IN ('done','partial')`, `fu_rollover_done = false`, `enable_cadence` e Uazapi. Rollover quando `success_count + failed_count >= planned_count`. Opcional: `sync_campaign_leads_from_uazapi` antes, se `UAZAPI_RECONCILE_FIND_BEFORE_ROLLOVER`; gate `should_block_initial_rollover_for_pending_find` (message_find / D9).
+
+- **Fila pós-create:** `_process_verify_folder_queue` — ~3 min após create, `list_folders` para verificar se a pasta existe (só log).
+
+---
+
+## 2. Tabela: cenário → comportamento atual → gap
+
+| Cenário | O que o código faz hoje | Gaps / observações |
+| --- | --- | --- |
+| **A. Instância desconectada / API 500 com `{"error":"No session"}`** | `create_advanced_campaign` recebe status ≠ 200, `raise_for_status` → exceção → retorno **`None`**. Materialize trata como falha: `status = 'failed'`, **sem** pasta. Não diferencia "No session" de outro 500 no retorno. | Operador: chunk `failed` sem `uazapi_folder_id`. Próximo chunk: só quando `schedule_next_initial_chunk` inserir de novo (não re-tenta sozinho no mesmo minuto). |
+| **B. Timeout ou 5xx genérico Uazapi** | Idem: `None` → linha `failed`. Logs em stderr da app/worker. | Idem. Sem classificação retryable vs terminal no código do cliente. |
+| **C. `scheduled` + `planned_count > 0` com `uazapi_folder_id` NULL após N min** | O INSERT de `schedule_next_initial_chunk` usa `planned_count = 0` e `lead_ids = '[]'`. O `planned_count` preenche **após** create bem-sucedido. Cenário real: linha fica `scheduled` sem pasta **e** 0 planeado — típico de: (1) ainda na janela de espera, (2) fora da janela UTC de materialize, (3) stale > TTL. Recovery: `_recover_stale_scheduled_initial_uazapi_sends` se `scheduled_for < now - 90 min` (env `UAZAPI_STALE_RECOVERY_TTL_MINUTES`): bump `scheduled_for` para `next_valid` **ou** `failed` (sem apikey, janela inválida, modo `mark_failed`). | Se N < TTL, a linha pode **permanecer** `scheduled` sem pasta (até entrar no materialize + lookback/lookahead). Admin: tabela de chunks mostra `scheduled` / pasta vazia. |
+| **D. Pasta criada, envio parcial (`success` + `failed` vs `planned`)** | Sync (`sync_campaign_leads_from_uazapi`) atualiza contagens a partir de listfolders (cap em `planned_count`) e `message_find` em estados D4. Rollover inicial: promove FU1 quando `succ + fail >= planned` — **falhas parciais na API não bloqueiam** avanço para quem recebeu envio. Leads que falharam na API podem permanecer em Inicial conforme reconciliação. | Operador pode ver `partial` e contagens; precisa de sync para alinhar leads. Documentado em docstrings do rollover. |
+| **E. “Dia seguinte” após falha (produção)** | `schedule_next_initial_chunk` coloca o próximo slot em geral com `cadence_next_initial_send_slot` → **um slot matinal no dia seguinte** (a menos que D1 + env + cota + janela permitam mesmo dia). `failed` **não** bloqueia nova linha. Se o operador **não** tiver cota / slot no mesmo dia, o próximo INSERT será naturalmente D+1. | Comportamento esperado dado o desenho “um insert automático por dia civil” + stale bump para `next_valid` (pode ser amanhã no início da janela). |
+
+**Admin (UI):** `templates/admin/campaigns.html` mostra colunas de stage, `scheduled_for`, `status`, contadores, `uazapi_folder_id`. Rota de flush stale em `app.py` chama `_recover_stale_scheduled_initial_uazapi_sends` com modos `recovery` / `mark_failed` (auditoria `admin_uazapi_stale_flush_audit`).
+
+**API “Continuar chunk”:** `app.py` — `POST /api/campaigns/<id>/continue-initial-chunk` → `_continue_initial_chunk_core` insere `scheduled` e chama `_materialize_scheduled_stage_sends(conn, force_send_ids=...)`. Respostas **200 / 207 / 502** conforme `utils/continue_initial_chunk_report.py` e presença de exceção na materialização imediata.
+
+---
+
+## 3. Débito técnico explícito
+
+| Tema | Onde aparece |
+| --- | --- |
+| **Regras duplicadas (continuar vs worker)** | `schedule_next_initial_chunk` e `_continue_initial_chunk_core` repetem: instâncias Uazapi, delays, `INITIAL_CHUNK_ACTIVE_SEND_STATUSES`, carga de mensagens step 1, INSERT de `campaign_stage_sends` — o app força janela com `now+30s` ou `next_valid` com margem `MATERIALIZE_LOOKAHEAD_MIN` quando fora da janela BRT. |
+| **Janelas materialize (lookahead/lookback)** | Constantes só em `worker_cadence.py`; comentário “SSOT” compartilhada entre SQL e Python. Qualquer `INSERT` de `scheduled_for` em `app.py` deve cair no intervalo de materialize automático ou depender de `force_send_ids` / tick seguinte. |
+| **`can_create_campaign_today` obsoleto** | `utils/limits.py` — retorno fixo `True`; materialize ainda contém o ramo condicional (inalcançável). Comentários em `initial_chunk_schedule_target.py` alertam. |
+| **Múltiplas camadas de feature flags** | `UAZAPI_SAME_DAY_INITIAL_CHUNK_AFTER_UNLOCK`, `UAZAPI_STALE_RECOVERY_*`, `UAZAPI_RECONCILE_FIND_BEFORE_ROLLOVER`, `UAZAPI_RECONCILE_FIND_BEFORE_CHUNK`, `UAZAPI_LEAD_RECONCILE_V2`, `UAZAPI_MESSAGE_FIND`, etc. — espalhadas com defaults distintos; risco de comportamento “depende do ambiente”. |
+| **TODOs / Task labels** | Docstrings em `worker_cadence.py` e `utils/sync_uazapi.py` referem Task 3/5/6/7, D1, D3, D4, D9, D10, F7, F10, T6–T10 — úteis para rastreio, mas misturam spec de produto e código. |
+| **Dois caminhos de rollover “Inicial → FU”** | `process_uazapi_initial_stage_rollovers` (cadência + Uazapi) vs `process_rollover` (rollover diário + list_messages Sent) — campanhas/configurações diferentes. |
+
+---
+
+## 4. Jornada ideal (recomendação de comportamento — sem implementar)
+
+**Princípio:** separar **(a) saúde da conexão WhatsApp**, **(b) transiente de API**, e **(c) política de agendamento de negócio** (cota, janela BRT, anti-spam).
+
+### 4.1 P0 (confiança operacional e recuperação)
+
+1. **Classificação de erro em `create_advanced_campaign`:** persistir categoria (`no_session` vs `timeout` vs `5xx` vs `4xx`) para métricas e **retry** distinto. Hoje tudo vira `None` + `failed` genérico.
+2. **“No session” / desconectado:** não tratar como falha terminal de negócio da mesma forma que validação: preferir `scheduled` com `scheduled_for` curto (backoff) + mensagem clara no admin, ou flag explícita `last_error_code` na linha do chunk.
+3. **Staleness sem surpresa:** alinhar expectativa: ou TTL < janela de materialize com bump agressivo, ou alerta proativo se `scheduled` sem pasta e `now - scheduled_for` > X minutos.
+4. **Uma fonte de verdade** para “posso criar outro chunk nesta instância?” (já existe `INITIAL_CHUNK_ACTIVE_SEND_STATUSES`; evitar duplicar condições em outro módulo).
+
+### 4.2 P1 (UX e alinhamento produto)
+
+1. **Rationale no admin** quando `scheduled` sem pasta: exibir *porquê* (fora de janela UTC, aguardando token, cota, stale recovery na próxima iteração).
+2. **Continuar chunk** (API) + worker: resposta 207/502 já dão pistas; unificar com mensagens de *instância desconectada* se o backend obtiver `get_status` opcionalmente antes de POST (custo: mais chamada HTTP).
+3. **Cota (G2)** e **D1** documentados no painel: operador entende D+1 vs mesmo dia.
+4. **Rollover com parcial:** UI já mostra contadores; especificar *copy* de que leads falhos na Uazapi podem ficar na Inicial até nova ação (comportamento atual do rollover).
+
+### 4.3 Ordem de prioridade sugerida
+
+| Prioridade | Item |
+| --- | --- |
+| **P0** | Observabilidade e taxonomia de erros de materialize; retentativas com backoff para erros conhecidos de sessão/5xx. |
+| **P0** | Revisar interação **stale recovery** (90 min) × **janela materialize** (15 min) — hoje gera estados “presos” conhecidos. |
+| **P1** | Unificar regra de agendamento entre `app` e `worker` (helper único de “próximo `scheduled_for`”). |
+| **P1** | Remover ou reimplementar `can_create_campaign_today` se não tiver efeito. |
+| **P2** | Documentar flags em um único `docs/` ou tabela de env (reduzir surpresas entre ambientes). |
+
+---
+
+## 5. Riscos (residuais)
+
+- **Janela UTC de materialize estreita:** chunks que “ficam para trás” > 15 min dependem de stale recovery ou de `force` via continue API; risco de operador ver linhas `scheduled` sem ação.
+- **Dupla natureza de `listfolders`:** se a API atrasar ou retornar lista sem a pasta, sync pode atrasar reconciliação (comentários já admitem “próximo listfolders ~10 min”).
+- **Pacing (múltiplos segmentos):** primeiro segmento com falha dá `break` — restantes daquele send podem não ser criados naquele passo.
+- **Segurança/operacional:** admin stale flush e force de campanha fora de `running|pending|completed` podem marcar `failed` em massa; existe auditoria, mas requer *runbook*.
+
+---
+
+## 6. Sugestão de testes
+
+### 6.1 Já existentes (referência)
+
+- `tests/test_worker_cadence_initial_chunk.py` — `INITIAL_CHUNK_ACTIVE_SEND_STATUSES`
+- `tests/test_worker_materialize_outside_brt.py` — materialize fora da janela BRT
+- `tests/test_worker_stale_recovery.py` — recovery de scheduled stale
+- `tests/test_sync_uazapi.py` — amplo cobertura de sync / message_find / orfãos
+- `tests/test_continue_initial_chunk_ac13.py` — outcomes por instância após continuar
+- `tests/test_campaign_send_policy.py` — política G1/G2/G3 e `check_initial_chunk_daily_quota_for_campaign`
+
+### 6.2 Manuais sugeridos
+
+1. **Desconectar** instância na Uazapi → deixar worker passar → verificar `campaign_stage_sends` (esperado: `failed` após materialize, sem `uazapi_folder_id`).
+2. **Simular** resposta 500 (mock ou proxy) no `/sender/advanced` → mesma verificação.
+3. **Chunk `scheduled` com `scheduled_for` no passado** > 90 min → após tick, verificar bump de `scheduled_for` ou `failed` conforme quota/apikey.
+4. **Criar pasta com sucesso** e interromper envio parcial → sync manual (rota ou worker) → contadores e `partial` / rollover.
+
+### 6.3 Automatizados (ideias)
+
+- **Unit:** mock de `UazapiService.create_advanced_campaign` retornando `None` e assert de `UPDATE ... status = 'failed'` em harness DB ou mock de cursor (padrão dos testes de `test_worker_*`).
+- **Unit:** `classify_initial_chunk_send_row` para combinações `scheduled` com e sem `uazapi_folder_id` (já parcialmente em `test_continue_initial_chunk_ac13`).
+- **Integração (se houver):** `process_cadence` com ordem garantida recovery → materialize, verificando que `force_send_ids` ignora janela (como em testes de materialize).
+
+---
+
+## 7. Índice de símbolos (localização rápida)
+
+| Símbolo / conceito | Local principal |
+| --- | --- |
+| `process_cadence`, `_materialize_scheduled_stage_sends`, `schedule_next_initial_chunk`, `process_uazapi_initial_stage_rollovers` | `worker_cadence.py` |
+| `MATERIALIZE_LOOKAHEAD_MIN`, `MATERIALIZE_LOOKBACK_MIN` | `worker_cadence.py` |
+| `_recover_stale_scheduled_initial_uazapi_sends` | `worker_cadence.py` |
+| `sync_campaign_leads_from_uazapi`, `sync_campaign_stage_sends_before_new_chunk` | `utils/sync_uazapi.py` |
+| `create_advanced_campaign`, `list_folders` | `services/uazapi.py` |
+| `INITIAL_CHUNK_ACTIVE_SEND_STATUSES`, `check_initial_chunk_daily_quota_for_campaign` | `utils/limits.py` |
+| `resolve_initial_chunk_schedule_target`, `cadence_next_initial_send_slot` | `utils/initial_chunk_schedule_target.py` |
+| `INITIAL_CHUNK_DAILY_QUOTA_POLICY` | `utils/campaign_send_policy.py` |
+| `_continue_initial_chunk_core`, `continue_initial_chunk` | `app.py` |
+| `summarize_initial_chunk_materialization_rows` | `utils/continue_initial_chunk_report.py` |
+| Rota admin stale recovery | `app.py` (lookup `_recover_stale_scheduled_initial_uazapi_sends`) |
+
+---
+
+*Documento produzido como análise estática do repositório; comportamento de produção pode depender de variáveis de ambiente não inspecionadas em runtime.*

--- a/docs/UAZAPI_SCHEDULE_MATERIALIZE_RESILIENCE_SPEC.md
+++ b/docs/UAZAPI_SCHEDULE_MATERIALIZE_RESILIENCE_SPEC.md
@@ -1,0 +1,219 @@
+# Especificação — refatoração: schedule, materialize e resiliência Uazapi
+
+**Status:** proposta de produto + engenharia (não implementada).  
+**Entrada obrigatória (QA / análise):** `docs/UAZAPI_SCHEDULE_CHUNKS_MATERIALIZE_EXPLORATORY.md` — gap analysis, fluxo atual, janela de materialize, e débito técnico (duplicação `app.py` / `worker_cadence`, ausência de taxonomia de erro no cliente Uazapi, `failed` sem `lead_ids` alocados, “dia seguinte” após slot matinal + `failed` não bloquear).
+
+---
+
+## 0. Problema e objetivos
+
+| Problema observado | O que a análise de QA atribui ao código de hoje |
+| --- | --- |
+| 500 com `No session` → utilizador sem aviso no produto | `create_advanced_campaign` devolve `None` para qualquer HTTP ≠ 200; materialize grava `failed` sem distinguir desconexão; não há notificação ao dono. |
+| Após chunk `failed` (sem folder), o próximo agendamento “parece” D+1 | `schedule_next_initial_chunk` usa slot matinal / `cadence_next_initial_send_slot`; `failed` não entra em `INITIAL_CHUNK_ACTIVE_SEND_STATUSES`, logo pode inserir nova linha no **próximo** slot canónico (sou muitas vezes manhã seguinte). `lead_ids` muitas vezes ainda `[]` no caminho de falha — risco de elegibilidade vs duplicação mal documentada. |
+
+**Objetivo da refatoração:** uma cadeia coerente **schedule → (pré-checagem) → create (API) → materialize → sync**, com:
+
+- estado persistido e inspeccionável;
+- retomada após falha **transiente** com backoff na **mesma janela de negócio** quando a política assim o exigir;
+- **sem** reenvio duplicado ao mesmo lead (alinhado a `lead_ids` + pastas Uazapi + sync);
+- **sem** abandono dos leads do chunk que falhou antes de pasta;
+- tratamento explícito de **desconexão** (utilizador avisado + campanha em estado controlado).
+
+**Fora de escopo (confirmado):** alterar o contrato da API Uazapi fora do cliente HTTP existente; redesign completo do admin (apenas estados / mensagens / hooks).
+
+---
+
+## 1. Decisões de produto (travadas nesta spec)
+
+### 1.1 Retentativa automática vs pausa após desconexão
+
+| Decisão | Escolha | Fundamento |
+| --- | --- | --- |
+| Após detetar instância **desconectada** (pré-checagem ou corpo `No session`) | **Pausa lógica da materialização** para essa instância/campanha: não chamar `create_advanced_campaign` em loop a cada 30s. | Evita carga na Uazapi e no worker; alinha com a realidade (reconexão é ação do utilizador). |
+| Retentativas **automáticas** | Aplicar só a erros classificados como **transientes** (rede, 502/503/504, timeout) **enquanto** a instância estiver **connected** (ou status desconhecido após 1 leitura). | Backoff com teto; não substitui reconexão. |
+| “Dia seguinte” | **Não** empurrar automaticamente para o próximo dia civil **só** porque houve um 5xx transiente na mesma janela; o **próximo** `scheduled_for` deve ser recalculado por uma **função única** (ver §4) com política: `retry_at` (backoff) vs `next_valid_brt` (janela) vs “slot diário canónico” (anti-flood). | Corrige a percepção de “saltou para amanhã” após falha evitável. |
+
+*Nota:* “Pausa lógica” pode mapear para `campaigns.status` auxiliar, coluna `materialization_block_reason`, ou tabela de fila; ver §3.1.
+
+### 1.2 Notificação (Parte A) — frequência máxima e idempotência
+
+| Regra | Valor sugerido (configurável) |
+| --- | --- |
+| Máximo de avisos **por (user_id, instance_id)** por incidente de desconexão | 1 notificação / 24h por defeito (env `SUPPORT_NOTIFY_DISCONNECT_COOLDOWN_HOURS` ou tabela `user_notification_cooldown`). |
+| Deduplicação | Chave: `hash(user_id, instance_id, 'uazapi_disconnected')` + janela temporal; persistir `last_notified_at` (ex.: em `instances` ou tabela `notification_log`). |
+| Opt-out | Env `SUPPORT_UAZAPI_NOTIFY_ENABLED=0` desliga avisos (só log + admin); opt-out por utilizador fica como P2 se necessário. |
+
+**Texto da mensagem (obrigatório, variáveis):**
+
+> `{nome}, sua instância de Whatsapp está desconectada. Acesse o *Leads Infinitos* e reconecte para garantir o funcionamento da sua automação.`
+
+- `{nome}`: display name do utilizador — **gap presente:** a tabela `users` no bootstrap de `app.py` hoje tem `email` + `password_hash` (sem coluna `name`); a implementação deve **adicionar** `display_name` (ou reutilizar email local antes de `@`) e, para WA, **número** de contacto (novo campo em `users` ou tabela de perfil). Até lá, fallback: e-mail transacional + log (ver §8).
+- Formatação `*negrito*` — confirmar se a API de envio (Uazapi `send_text`) suporta metadados WhatsApp; se não, enviar texto plano sem `*`.
+
+### 1.3 “Restart/reconnect” (limitação Uazapi)
+
+- **Spec técnica:** a rotina de **reconnect** no produto = **sinalizar ao utilizador** (notificação Parte A) + link para o fluxo já existente de QR/conexão no app (não supor `POST /instance/connect` em loop sem ação do utilizador, salvo alinhamento explícito com a documentação Uazapi e testes de segurança).
+- Opcional (flag): **uma** tentativa de `UazapiService.connect(token)` (instância avariada) apenas se o prod quiser “despertar” sessão — default **off**.
+
+---
+
+## 2. Parte A — Notificação e pré-checagem (engenharia)
+
+### 2.1 Granularidade e ordem
+
+| Momento | Ação | Motivo |
+| --- | --- | --- |
+| **A — Por tentativa** imediatamente **antes** de `create_advanced_campaign` (e opcionalmente antes de `POST` no mesmo tick para FU) | `get_status(token_campanha)` na instância do send | Rejeitar cedo; evita 500 e classifica desconexão. |
+| **B — Por tick (opcional / cache)** | Não invocar `get_status` para todas as instâncias a cada 30s sem cache; TTL em memória Redis **ou** “última leitura + 60s” por `instance_id` | NFR: rate limit à API Uazapi. |
+| Se `get_status` falhar (None / timeout) | Não notificar desconexão; tratar como “desconhecido” e deixar fluxo de erro transiente (ou 1 retry de status). | Evitar falso “disconnected”. |
+
+**Decisão:** o pré-checque **mínimo** exigido para esta spec é **por tentativa de materialize**; cache por tick é **recomendado** antes do volume subir.
+
+### 2.2 Aviso ao “número do cliente” via instância de suporte
+
+- **Token:** lido de variável de ambiente `SUPPORT_UAZAPI_INSTANCE_TOKEN` (nunca commitar o valor; inject no deploy).
+- **Destinatário:** número de WhatsApp do **dono** da campanha — provavelmente **não** existe no schema atual; a spec exige **migração** `users.phone_e164` (ou entidade `user_contact`) **ou** uso de telefone já guardado em outra tabela (a confirmar no desenho). Enquanto inexistente: notificação **não-WA** (e-mail) + banner in-app para cumprir o “utilizador avisado” de forma honesta.
+- **Envio:** `UazapiService.send_text(support_token, e164_destino, message)` (ou API equivalente já usada no projeto). Validar tamanho e JID.
+- **Segurança:** token de suporte só em segredo/secret manager; logs **sem** token; sem PII além do necessário em logs estruturados.
+
+### 2.3 NFR: logs e métricas
+
+Log estruturado (JSON) sugerido:
+
+- `event`: `uazapi_precheck`, `uazapi_disconnect_notify_skipped_cooldown`, `uazapi_disconnect_notify_sent`, `uazapi_materialize_blocked_disconnected`
+- `campaign_id`, `instance_id`, `user_id`, `send_id` (quando existir)
+- Nunca logar `apikey` / token.
+
+---
+
+## 3. Parte B — Estados, invariantes e sync de leads
+
+### 3.1 Máquina de estados alvo — `campaign_stage_sends` (etapa Uazapi com pasta)
+
+```mermaid
+stateDiagram-v2
+    [*] --> scheduled: schedule_next / continue API
+    scheduled --> materializing: entrou na janela de materialize
+    materializing --> running: create OK, folder_id persistido
+    materializing --> scheduled: falha transiente, backoff (mesmo lead_ids)
+    materializing --> waiting_reconnect: disconnected / No session
+    waiting_reconnect --> scheduled: instance connected again (retry)
+    scheduled --> failed: esgotou retries / terminal / política
+    running --> partial: envio Uazapi em andamento
+    running --> done: concluído + sync
+    partial --> done: concluído
+    running --> failed: cancel / irreversível (só com regra explícita)
+```
+
+**Notas:**
+
+- `materializing` pode ser **sub-estado** implementado com coluna `materialize_attempt_at` + `status=scheduled` **ou** valor de enum novo — decisão de schema em §5.
+- `waiting_reconnect` pode ser `campaigns.uazapi_materialize_paused` + `reason=disconnected` se preferir **uma** coluna a nível de campanha em vez de por linha.
+
+**Invariantes:**
+
+1. Se `uazapi_folder_id` IS NULL, não pode existir `status IN ('running','partial','done')` (exceto se definirem `running` sem folder legado; migração deve normalizar).
+2. Se `lead_ids` preenchido e sem folder, a linha está em **pré-API** (materializing ou scheduled com retry) — o SQL de **exclusão** de leads para novo chunk (ver análise QA) deve considerar **reserva** explícita (ver §3.2).
+
+### 3.2 Leads no chunk: modelo único pós-refatoração (proposta)
+
+| Conceito | Comportamento alvo | Relação com o gap atual |
+| --- | --- | --- |
+| **Reserva** | Ao alocar leads a um `send_id` **antes** de `create_advanced_campaign`, persistir `lead_ids` (e opcionalmente `reservation_status=pending_create`). | Hoje, em falha cedo, `lead_ids` pode continuar `[]` — a exclusão SQL de outros chunks pode **re-oferecer** o mesmo lead ou gerar condição de corrida. |
+| **Elegibilidade** | Leads em `reservation` para um send **falhado** sem folder tornam-se elegíveis **só** após `release` explícita (falha terminal) ou reassign para novo `send_id` na mesma campanha/etapa. | Garante “sem abandono” e “sem duplicar” alinhado a sync. |
+| **Já contabilizado na Uazapi** | Continuar a tratar `last_sent_folder_id` + sync (como hoje) como prova de envio; não realocar lead com envio confirmado. | Não regressão. |
+
+**Critério de aceite B3:** se um chunk falha **sem** folder, os leads alocados nesse send devem **aparecer** no próximo `schedule`/`materialize` (novo `send_id` ou retry na mesma linha conforme decisão) **sem** duplicar envio já em pasta anterior.
+
+### 3.3 Falhas transientes: política de `scheduled_for`
+
+- Classificar erros: `transient_network`, `transient_5xx`, `transient_no_session` (a última, na prática, vira **waiting_reconnect** após notificação — não D+1 automático).
+- `next_attempt_at_utc` = `now + backoff(attempt)` com teto (ex. máx. 1h para worker 30s → tentativas espalhadas N vezes, não spam).
+- **Não** substituir por `cadence_next_initial_send_slot` **apenas** por ter falhado; só usar slot matinal D+1 quando a política de **anti-flood** ou cota exigir (reuso da função única de §4).
+
+### 3.4 Fonte de verdade única (Parte B4)
+
+Extrair módulo compartilhado, por exemplo `utils/uazapi_chunk_schedule.py` (nome final livre), responsável por:
+
+- Dado: `campaign` (janela BRT, `scheduled_start`, cota, flags D1), `context` (retry vs primeiro chunk do dia), `now_utc`  
+- Devolver: `ScheduledDecision { scheduled_for_utc_naive, allow_insert, reason, policy_tag }`  
+- Consumidores: `worker_cadence.schedule_next_initial_chunk`, `app._continue_initial_chunk_core`, (opcional) `recover_stale` para bump coerente.
+
+**Eliminar divergência:** hoje o app usa `now+30s` ou `next_valid` com `MATERIALIZE_LOOKAHEAD_MIN`; o worker usa `initial_chunk_schedule_target` + `next_valid` com margem 0 — tudo passa a uma **única** política parametrizada.
+
+Janela de **materialize** (`LOOKAHEAD/LOOKBACK`) permanece NFR do worker, mas a **regra de negócio** “quando o próximo chunk pode existir” não depende de constantes espalhadas.
+
+---
+
+## 4. Sequência alvo (visão de runtime)
+
+```mermaid
+sequenceDiagram
+    participant W as worker_cadence
+    participant S as uazapi_schedule (SSOT)
+    participant P as precheck get_status
+    participant U as Uazapi API
+    participant N as support notify
+    W->>S: próximo slot / retry
+    S-->>W: scheduled_for, metadata
+    W->>P: get_status(instance)
+    alt disconnected
+        W->>N: notify (cooldown)
+        W-->>W: state waiting_reconnect or pause campaign
+    else ok / unknown
+        W->>U: create_advanced_campaign
+        alt 5xx/timeout
+            W-->>W: backoff, persist error class
+        else 200+folder
+            W-->>W: running, sync
+        end
+    end
+```
+
+---
+
+## 5. Plano de migração de dados
+
+1. **Inventário:** linhas `status='scheduled' AND uazapi_folder_id IS NULL` com `scheduled_for` muito no passado — já coberto por `UAZAPI_STALE_RECOVERY_TTL_MINUTES` (rever para alinhar com nova coluna de retry).
+2. **Normalização:** backfill de `last_materialize_error_code` nulo; mapear `failed` recents → `failed|retryable` só se houver log (opcional, pode ser forward-only).
+3. **Reserva de `lead_ids`:** migração pode **não** forçar backfill; a partir de versão N, **todo** materialize que escolhe leads grava `lead_ids` **antes** do `POST` (transação: lock de leads vs duplicata).
+4. **Compatibilidade:** manter `INITIAL_CHUNK_ACTIVE_SEND_STATUSES` sincronizado com o novo enum (ex.: adicionar `materializing` e `waiting_reconnect` se bloquearem o mesmo que `scheduled`).
+
+---
+
+## 6. Critérios de aceite mensuráveis (MVP desta spec)
+
+1. **Desconexão durante campanha:** utilizador recebe **no máximo 1** WhatsApp de suporte / 24h / instância (com cooldown) quando a desconexão for detetada no fluxo; log `uazapi_disconnect_notify_sent` ou `skipped` com motivo.
+2. **Pausa vs retry:** campanha/instância com desconexão **não** gera N chamadas a `create_advanced_campaign` com o mesmo padrão de failure; após reconexão (status connected), o worker retoma (transição `waiting_reconnect` → `scheduled`/`materializing`).
+3. **Chunk sem folder após alocação:** leads do chunk **não** saem do conjunto de pendentes sem decisão; próximo sucesso **não** reenvia para o mesmo lead que já consta como enviado noutra pasta (invariantes de sync atuais preservados).
+4. **Não regressão:** `sync_campaign_leads_from_uazapi`, listfolders, contadores e admin (visão mínima de estado/reason) permanecem coerentes; testes existentes de `test_sync_uazapi.py` / `test_worker_*` ajustados.
+
+---
+
+## 7. Testes (além do documento de QA)
+
+- **Unit:** classificador de erros a partir de `response` JSON (`No session`) e status HTTP, sem chamar rede.
+- **Unit:** `ScheduledDecision` — mesmo input → mesmo output para worker e app.
+- **Integração (opcional):** mock Uazapi: sequência get_status → disconnected → notify 1x → get_status → connected → create success.
+- **Carga:** com cooldown, garantir N ticks não geram N `send_text` de suporte.
+
+---
+
+## 8. Dependências e riscos
+
+- **Dependência directa do QA:** análise em `docs/UAZAPI_SCHEDULE_CHUNKS_MATERIALIZE_EXPLORATORY.md` (gaps C, E, débito duplicação, janela UTC 15+5 min).
+- **Número do utilizador:** se o produto ainda não tiver telemóvel obrigatório, a Parte A precisa de **fallback** (e-mail + banner in-app) para cumprir o “utilizador avisado” na aceite 1.
+- **Token de suporte:** operação (deploy) deve fornecer `SUPPORT_UAZAPI_INSTANCE_TOKEN`; risco de ambiente de staging sem token — deflag `SUPPORT_UAZAPI_NOTIFY_ENABLED`.
+
+---
+
+## 9. Changelog
+
+| Data | Nota |
+| --- | --- |
+| 2026-04-29 | Versão inicial da spec, alinhada à análise de QA e requisitos de negócio. |
+
+---
+
+*Texto aprovado para início de desenho técnico (tasks) e estimativa; ajustar decisões 1.1/1.2 com PM se “pausa lógica” tiver de refletir-se no Kanban (UI mínima).*

--- a/services/uazapi.py
+++ b/services/uazapi.py
@@ -295,11 +295,20 @@ class UazapiService:
                 url, json=payload, headers=headers, timeout=30
             )
             if response.status_code != 200:
+                err_body: Any = None
+                try:
+                    err_body = response.json()
+                except Exception:
+                    err_body = {"raw": (getattr(response, "text", None) or "")[:8000]}
                 print(
                     f"❌ [Uazapi] create_advanced_campaign Status: {response.status_code}"
                 )
                 print(f"❌ [Uazapi] create_advanced_campaign Body: {response.text}")
-            response.raise_for_status()
+                return {
+                    "uazapi_request_failed": True,
+                    "http_status": response.status_code,
+                    "error_body": err_body,
+                }
             data = response.json()
             if os.environ.get("UAZAPI_DEBUG", "").strip().lower() in ("1", "true", "yes"):
                 try:
@@ -312,7 +321,23 @@ class UazapiService:
             print(f"❌ [Uazapi] Error creating advanced campaign: {e}")
             if hasattr(e, "response") and e.response is not None:
                 print(f"❌ [Uazapi] Response: {e.response.text}")
-            return None
+            status = None
+            err_body: Any = None
+            if hasattr(e, "response") and e.response is not None:
+                try:
+                    status = e.response.status_code
+                except Exception:
+                    status = None
+                try:
+                    err_body = e.response.json()
+                except Exception:
+                    err_body = (getattr(e.response, "text", None) or str(e))[:4000]
+            return {
+                "uazapi_request_failed": True,
+                "http_status": status,
+                "error_body": err_body,
+                "exception": str(e)[:2000],
+            }
 
     def edit_campaign(
         self, token: str, folder_id: str, action: str

--- a/templates/admin/campaigns.html
+++ b/templates/admin/campaigns.html
@@ -10,6 +10,11 @@
             <p class="text-gray-400">Todas as campanhas do sistema</p>
         </div>
         <div class="flex gap-4">
+            <button type="button" onclick="openForceChunkModal()"
+                class="btn bg-violet-600 hover:bg-violet-700 text-white px-4 py-2 rounded-lg font-medium transition-colors"
+                title="Forçar novo chunk inicial (Uazapi + cadência) com leads ainda pendentes">
+                ⚡ Forçar chunk (Uazapi)
+            </button>
             <a href="{{ url_for('admin_new_campaign') }}"
                class="btn bg-green-600 hover:bg-green-700 text-white px-4 py-2 rounded-lg font-medium transition-colors">
                 + Nova Campanha
@@ -129,6 +134,44 @@
     </div>
 </div>
 
+<!-- Modal: forçar chunk inicial (admin) -->
+<div id="force-chunk-modal" class="fixed inset-0 z-[60] hidden items-center justify-center p-4 bg-black/80"
+    onclick="if(event.target===this) closeForceChunkModal()">
+    <div class="bg-gray-900 border border-violet-600/40 rounded-xl max-w-lg w-full shadow-2xl"
+        onclick="event.stopPropagation()">
+        <div class="px-5 py-4 border-b border-gray-700">
+            <h2 class="text-lg font-semibold text-white">Forçar chunk inicial (Uazapi)</h2>
+            <p class="text-sm text-gray-400 mt-1">Cancela envios iniciais agendados/retomada e cria pastas de envio
+                imediato, apenas para a etapa 1, com os leads que ainda não tiveram mensagem.</p>
+        </div>
+        <div class="px-5 py-4 space-y-4 text-sm text-gray-300">
+            <div>
+                <label class="block text-gray-400 mb-1">ID da campanha *</label>
+                <input type="number" id="force-campaign-id" min="1"
+                    class="w-full bg-gray-800 border border-gray-600 rounded px-3 py-2 text-white"
+                    placeholder="ex.: 210" />
+            </div>
+            <div>
+                <label class="block text-gray-400 mb-1">Confirmação: nome exato (opcional)</label>
+                <input type="text" id="force-confirm-name"
+                    class="w-full bg-gray-800 border border-gray-600 rounded px-3 py-2 text-white"
+                    placeholder="Cole o nome completo se quiser evitar enganos" />
+            </div>
+            <label class="flex items-center gap-2 cursor-pointer">
+                <input type="checkbox" id="force-cancel-scheduled" checked class="rounded border-gray-600" />
+                <span>Cancelar chunks iniciais agendados/retomada (recomendado p/ destravar)</span>
+            </label>
+            <pre id="force-chunk-output" class="hidden text-xs bg-black/50 border border-gray-700 rounded p-3 max-h-64 overflow-y-auto text-left whitespace-pre-wrap break-words"></pre>
+        </div>
+        <div class="px-5 py-3 border-t border-gray-700 flex justify-end gap-2">
+            <button type="button" onclick="closeForceChunkModal()"
+                class="px-4 py-2 rounded-lg bg-gray-700 hover:bg-gray-600 text-white">Cancelar</button>
+            <button type="button" id="force-chunk-submit" onclick="submitForceChunk()"
+                class="px-4 py-2 rounded-lg bg-violet-600 hover:bg-violet-500 text-white font-medium">Executar</button>
+        </div>
+    </div>
+</div>
+
 <!-- Modal detalhes (superadmin) -->
 <div id="campaign-detail-modal" class="fixed inset-0 z-50 hidden items-center justify-center p-4 bg-black/70"
     onclick="if(event.target===this) closeCampaignDetail()">
@@ -147,6 +190,7 @@
 
 <script src="https://cdn.tailwindcss.com"></script>
 <script>
+    const ADMIN_CSRF = {{ csrf_token|tojson }};
     function esc(s) {
         if (s === null || s === undefined) return '';
         const d = document.createElement('div');
@@ -160,11 +204,73 @@
         m.classList.remove('flex');
     }
 
+    function openForceChunkModal() {
+        document.getElementById('force-chunk-output').classList.add('hidden');
+        document.getElementById('force-chunk-output').textContent = '';
+        const m = document.getElementById('force-chunk-modal');
+        m.classList.remove('hidden');
+        m.classList.add('flex');
+        document.getElementById('force-campaign-id').focus();
+    }
+
+    function closeForceChunkModal() {
+        const m = document.getElementById('force-chunk-modal');
+        m.classList.add('hidden');
+        m.classList.remove('flex');
+    }
+
+    async function submitForceChunk() {
+        const idEl = document.getElementById('force-campaign-id');
+        const out = document.getElementById('force-chunk-output');
+        const cid = parseInt(idEl.value, 10);
+        if (!cid || cid < 1) {
+            out.classList.remove('hidden');
+            out.textContent = 'Informe um ID de campanha válido.';
+            return;
+        }
+        const body = {
+            campaign_id: cid,
+            cancel_scheduled: document.getElementById('force-cancel-scheduled').checked,
+            confirm_name: (document.getElementById('force-confirm-name').value || '').trim(),
+        };
+        if (ADMIN_CSRF) body.csrf_token = ADMIN_CSRF;
+        const btn = document.getElementById('force-chunk-submit');
+        btn.disabled = true;
+        out.classList.remove('hidden');
+        out.textContent = 'A executar...';
+        try {
+            const res = await fetch('/api/admin/campaigns/force-initial-chunk', {
+                method: 'POST',
+                headers: { 'Content-Type': 'application/json', 'X-CSRF-Token': ADMIN_CSRF || '' },
+                body: JSON.stringify(body),
+            });
+            const data = await res.json().catch(() => ({}));
+            const text = JSON.stringify(data, null, 2);
+            if (!res.ok) {
+                out.textContent = 'Erro HTTP ' + res.status + ':\n' + text;
+                console.error('force-initial-chunk', data);
+                return;
+            }
+            out.textContent = text;
+        } catch (e) {
+            out.textContent = 'Falha de rede: ' + e.message;
+        } finally {
+            btn.disabled = false;
+        }
+    }
+
     document.addEventListener('keydown', function (e) {
         if (e.key !== 'Escape') return;
+        const fm = document.getElementById('force-chunk-modal');
+        if (fm && !fm.classList.contains('hidden')) {
+            e.preventDefault();
+            closeForceChunkModal();
+            return;
+        }
         const m = document.getElementById('campaign-detail-modal');
-        if (!m || m.classList.contains('hidden')) return;
-        closeCampaignDetail();
+        if (m && !m.classList.contains('hidden')) {
+            closeCampaignDetail();
+        }
     });
 
     async function openCampaignDetail(id) {
@@ -180,6 +286,8 @@
                 body.innerHTML = '<p class="text-red-400">' + esc(data.error || 'Erro ao carregar') + '</p>';
                 return;
             }
+            const fc = document.getElementById('force-campaign-id');
+            if (fc) fc.value = id;
             body.innerHTML = renderCampaignDetail(data);
         } catch (err) {
             body.innerHTML = '<p class="text-red-400">' + esc(err.message) + '</p>';

--- a/templates/admin/campaigns.html
+++ b/templates/admin/campaigns.html
@@ -141,8 +141,11 @@
         onclick="event.stopPropagation()">
         <div class="px-5 py-4 border-b border-gray-700">
             <h2 class="text-lg font-semibold text-white">Forçar chunk inicial (Uazapi)</h2>
-            <p class="text-sm text-gray-400 mt-1">Cancela envios iniciais agendados/retomada e cria pastas de envio
-                imediato, apenas para a etapa 1, com os leads que ainda não tiveram mensagem.</p>
+            <p class="text-sm text-gray-400 mt-1">Cria o próximo lote de envio inicial (Uazapi) para pendentes que
+                ainda não tiveram mensagem. <span class="text-amber-300/90">Com cadência:</span> agendamento
+                + materialize imediato. <span class="text-amber-300/90">Sem cadência:</span> criação direta
+                (create_advanced) como no fluxo de nova campanha. Opcional: cancela chunks
+                iniciais agendados/retomada presos.</p>
         </div>
         <div class="px-5 py-4 space-y-4 text-sm text-gray-300">
             <div>

--- a/tests/test_uazapi_error_taxonomy.py
+++ b/tests/test_uazapi_error_taxonomy.py
@@ -1,0 +1,30 @@
+from utils.uazapi_error_taxonomy import classify_create_advanced_error, format_last_error_for_db
+
+
+def test_classify_no_session_message():
+    r = {
+        "uazapi_request_failed": True,
+        "http_status": 500,
+        "error_body": {"error": "No session"},
+    }
+    cat, msg, http = classify_create_advanced_error(r)
+    assert cat == "no_session"
+    assert http == 500
+
+
+def test_classify_transient_503():
+    r = {
+        "uazapi_request_failed": True,
+        "http_status": 503,
+        "error_body": {"message": "unavailable"},
+    }
+    cat, _m, _h = classify_create_advanced_error(r)
+    assert cat == "transient_http"
+
+
+def test_format_last_error_json():
+    s = format_last_error_for_db(
+        {"uazapi_request_failed": True, "http_status": 500, "error_body": {"a": 1}},
+        "no_session",
+    )
+    assert "no_session" in s

--- a/utils/continue_initial_chunk_report.py
+++ b/utils/continue_initial_chunk_report.py
@@ -15,6 +15,8 @@ def classify_initial_chunk_send_row(row: dict) -> str:
     has_folder = fid is not None and str(fid).strip() != ""
     if st == "failed":
         return "failed"
+    if st == "waiting_reconnect":
+        return "waiting_reconnect"
     if has_folder or st in ("running", "partial", "queued"):
         return "materialized"
     if st == "scheduled":
@@ -48,7 +50,12 @@ def summarize_initial_chunk_materialization_rows(
             }
         )
 
-    relevant = kinds & {"materialized", "failed", "scheduled_pending_worker"}
+    relevant = kinds & {
+        "materialized",
+        "failed",
+        "scheduled_pending_worker",
+        "waiting_reconnect",
+    }
     partial = len(relevant) > 1
     all_failed = bool(per_send) and all(p["outcome"] == "failed" for p in per_send)
     return per_send, partial, all_failed

--- a/utils/limits.py
+++ b/utils/limits.py
@@ -19,11 +19,18 @@ INFINITE_DAILY_SEND_OPTIONS = (10, 20, 30, 40, 50)
 # campaign_stage_sends (stage initial): só estes status bloqueiam novo chunk na mesma instância
 # (worker_cadence.schedule_next_initial_chunk, _continue_initial_chunk_core busy check).
 # failed/done não entram — após pasta órfã (sync → failed), a instância volta a poder receber chunk.
+# waiting_reconnect: instância desconectada; materialização pausada até reconexão.
 #
 # TD-7 / T8: inclui ``queued`` para alinhar com ``app.py`` (legado ou futuro). Após ``create_advanced_campaign``
 # bem-sucedido, o worker grava ``status='running'`` na BD mesmo quando a API Uazapi devolve ``status=queued``
 # na pasta — ``queued`` aqui é estado de *linha* em campaign_stage_sends, não o status remoto da API.
-INITIAL_CHUNK_ACTIVE_SEND_STATUSES = ("scheduled", "running", "partial", "queued")
+INITIAL_CHUNK_ACTIVE_SEND_STATUSES = (
+    "scheduled",
+    "running",
+    "partial",
+    "queued",
+    "waiting_reconnect",
+)
 
 # Fonte única de regras de plano.
 # validity_days: dias até expiração (a partir da data de aplicação ao usuário).

--- a/utils/sync_uazapi.py
+++ b/utils/sync_uazapi.py
@@ -916,7 +916,7 @@ def sync_campaign_leads_from_uazapi(conn, campaign_id, token, folder_id, uazapi_
                JOIN instances i ON i.id = css.instance_id
                WHERE css.campaign_id = %s
                  AND css.uazapi_folder_id IS NOT NULL
-                 AND css.status IN ('scheduled', 'running', 'partial', 'done')""",
+              AND css.status IN ('scheduled', 'running', 'partial', 'waiting_reconnect')
             (campaign_id,),
         )
         stage_sends = cur.fetchall() or []

--- a/utils/uazapi_error_taxonomy.py
+++ b/utils/uazapi_error_taxonomy.py
@@ -1,0 +1,86 @@
+"""
+Classificação de erros de create_advanced_campaign e respostas Uazapi.
+Usado para materialize (retry vs waiting_reconnect vs failed).
+"""
+
+from __future__ import annotations
+
+import json
+from typing import Any, Optional, Tuple
+
+
+def _lower_str(x: Any) -> str:
+    if x is None:
+        return ""
+    return str(x).lower()
+
+
+def classify_create_advanced_error(
+    result: Optional[dict[str, Any]],
+) -> Tuple[str, str, Optional[int]]:
+    """
+    Devolve (category, message, http_status).
+
+    category:
+      - no_session: desconexão / sessão inválida (não retentar create até reconectar)
+      - transient_http: 502/503/504 (retentar com backoff)
+      - client_error: 4xx
+      - server_error: 5xx que não seja transient
+      - empty_response: resposta vazia / sem folder sem payload de erro
+    """
+    if not result:
+        return "empty_response", "no result", None
+    if result.get("uazapi_request_failed"):
+        code = result.get("http_status")
+        body = result.get("error_body")
+        msg = ""
+        if isinstance(body, dict):
+            msg = _lower_str(
+                body.get("error")
+                or body.get("message")
+                or body.get("Message")
+            )
+        elif isinstance(body, str):
+            msg = _lower_str(body)
+        if not msg and result.get("exception"):
+            msg = _lower_str(result.get("exception"))
+        if "no session" in msg or "no_session" in msg or "desconect" in msg:
+            return "no_session", msg or "no session", code
+        if code in (502, 503, 504):
+            return "transient_http", msg or f"http {code}", code
+        if code is not None and 400 <= int(code) < 500:
+            return "client_error", msg or f"http {code}", code
+        if code is not None and int(code) >= 500:
+            return "server_error", msg or f"http {code}", code
+        return "transient_http", msg or "request failed", code
+    # Success shape without folder
+    if not (result.get("folder_id") or result.get("folderId")):
+        err = _lower_str(
+            result.get("error") or result.get("message") or result.get("Message")
+        )
+        if "no session" in err:
+            return "no_session", err, None
+        return "empty_response", err or "missing folder_id", None
+    return "ok", "", None
+
+
+def format_last_error_for_db(result: Optional[dict[str, Any]], category: str) -> str:
+    """JSON curto para campaign_stage_sends.last_materialize_error (até ~2k)."""
+    if not result:
+        return json.dumps(
+            {"category": category, "detail": "empty"}, ensure_ascii=False
+        )[:2000]
+    if result.get("uazapi_request_failed"):
+        return json.dumps(
+            {
+                "category": category,
+                "http_status": result.get("http_status"),
+                "error_body": result.get("error_body"),
+                "exception": (result.get("exception") or "")[:500],
+            },
+            ensure_ascii=False,
+            default=str,
+        )[:2000]
+    return json.dumps(
+        {"category": category, "body": str(result)[:1500]}, ensure_ascii=False
+    )[:2000]

--- a/utils/uazapi_support_notify.py
+++ b/utils/uazapi_support_notify.py
@@ -1,0 +1,229 @@
+"""
+Notificação ao dono da campanha quando a instância Uazapi está desconectada.
+Token: SUPPORT_UAZAPI_INSTANCE_TOKEN. Cooldown: instances.last_disconnect_notify_at
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import re
+import time
+from datetime import datetime, timedelta
+from typing import Any, Optional, Tuple
+
+import psycopg2
+from psycopg2.extras import RealDictCursor
+
+# (instance_id, monotonic) — TTL 60s para get_status
+_status_cache: dict[int, tuple[Any, float]] = {}
+_STATUS_CACHE_TTL_SEC = 60.0
+
+
+def get_instance_status_cached(
+    uazapi_service, instance_id: int, token: str
+) -> Optional[dict[str, Any]]:
+    """
+    get_status com cache 60s por instance_id (reduz chamadas no worker 30s).
+    """
+    if not uazapi_service or not token:
+        return None
+    now = time.monotonic()
+    if instance_id in _status_cache:
+        data, ts = _status_cache[instance_id]
+        if now - ts < _STATUS_CACHE_TTL_SEC:
+            return data
+    st = uazapi_service.get_status((token or "").strip())
+    _status_cache[instance_id] = (st, now)
+    return st
+
+
+def _parse_disconnected_cooldown_hours() -> int:
+    raw = os.environ.get("SUPPORT_NOTIFY_DISCONNECT_COOLDOWN_HOURS", "24")
+    try:
+        h = int((raw or "24").strip())
+    except (TypeError, ValueError):
+        h = 24
+    return max(1, min(h, 168))
+
+
+def is_instance_disconnected_status(status_payload: Optional[dict[str, Any]]) -> bool:
+    if not status_payload:
+        return False
+    inst = status_payload.get("instance")
+    if isinstance(inst, dict):
+        st = (inst.get("status") or inst.get("state") or "").lower()
+    else:
+        st = (status_payload.get("status") or status_payload.get("state") or "").lower()
+    return st in ("disconnected", "close", "closed", "logout", "offline")
+
+
+def _user_display_name(email: Optional[str]) -> str:
+    if not email or not str(email).strip():
+        return "Cliente"
+    local = str(email).split("@", 1)[0].replace(".", " ").replace("_", " ")
+    return local.strip().title() or "Cliente"
+
+
+def _digits_only(phone: str) -> str:
+    return re.sub(r"\D", "", str(phone or ""))
+
+
+def _support_message(nome: str) -> str:
+    # Texto de produto: sem * se preferir plano; manter * para WhatsApp
+    return (
+        f"{nome}, sua instância de Whatsapp está desconectada. "
+        f"Acesse o *Leads Infinitos* e reconecte para garantir o funcionamento da sua automação."
+    )
+
+
+def maybe_send_disconnect_support_whatsapp(
+    conn,
+    uazapi_service,
+    *,
+    campaign_id: int,
+    user_id: int,
+    instance_id: int,
+    context: Optional[dict] = None,
+) -> str:
+    """
+    Envia 1x por janela de cooldown por instância.
+    Returns: "sent" | "skipped_cooldown" | "disabled" | "no_support_token" | "no_user_phone" | "send_failed" | "error:..."
+    """
+    ctx = context or {}
+    if (os.environ.get("SUPPORT_UAZAPI_NOTIFY_ENABLED", "1").strip().lower() in (
+        "0",
+        "false",
+        "no",
+        "off",
+    )):
+        return "disabled"
+    support_token = (os.environ.get("SUPPORT_UAZAPI_INSTANCE_TOKEN") or "").strip()
+    if not support_token or not uazapi_service:
+        print(
+            json.dumps(
+                {
+                    "event": "uazapi_disconnect_notify",
+                    "reason": "no_support_token",
+                    "campaign_id": campaign_id,
+                    "instance_id": instance_id,
+                    "user_id": user_id,
+                },
+                ensure_ascii=False,
+            ),
+            flush=True,
+        )
+        return "no_support_token"
+    with conn.cursor(cursor_factory=RealDictCursor) as cur:
+        cur.execute("SELECT id, last_disconnect_notify_at FROM instances WHERE id = %s", (instance_id,))
+        row = cur.fetchone()
+    if not row:
+        return "error:instance_not_found"
+    last = row.get("last_disconnect_notify_at")
+    cool_h = _parse_disconnected_cooldown_hours()
+    if last is not None:
+        try:
+            if getattr(last, "tzinfo", None) is not None:
+                from datetime import timezone
+
+                last_cmp = last.astimezone(timezone.utc).replace(tzinfo=None)
+            else:
+                last_cmp = last
+        except Exception:
+            last_cmp = None
+        if last_cmp is not None and datetime.utcnow() - last_cmp < timedelta(
+            hours=cool_h
+        ):
+            print(
+                json.dumps(
+                    {
+                        "event": "uazapi_disconnect_notify_skipped_cooldown",
+                        "campaign_id": campaign_id,
+                        "instance_id": instance_id,
+                        "user_id": user_id,
+                        "last_notified_at": str(last),
+                    },
+                    ensure_ascii=False,
+                ),
+                flush=True,
+            )
+            return "skipped_cooldown"
+
+    with conn.cursor(cursor_factory=RealDictCursor) as cur:
+        cur.execute("SELECT id, email, display_name, phone_e164 FROM users WHERE id = %s", (user_id,))
+        u = cur.fetchone()
+    if not u:
+        return "error:no_user"
+    email = (u.get("email") or "").strip()
+    nome = (u.get("display_name") or "").strip() or _user_display_name(email)
+    dest = (u.get("phone_e164") or "").strip()
+    digits = _digits_only(dest)
+    if not digits or len(digits) < 10:
+        print(
+            json.dumps(
+                {
+                    "event": "uazapi_disconnect_notify",
+                    "reason": "no_user_phone",
+                    "campaign_id": campaign_id,
+                    "instance_id": instance_id,
+                    "user_id": user_id,
+                },
+                ensure_ascii=False,
+            ),
+            flush=True,
+        )
+        return "no_user_phone"
+
+    if len(digits) <= 11 and not digits.startswith("55"):
+        digits = "55" + digits
+
+    text = _support_message(nome)
+    try:
+        r = uazapi_service.send_text(support_token, digits, text)
+    except Exception as e:
+        print(
+            json.dumps(
+                {
+                    "event": "uazapi_disconnect_notify_error",
+                    "error": str(e)[:500],
+                    "campaign_id": campaign_id,
+                    "instance_id": instance_id,
+                },
+                ensure_ascii=False,
+            ),
+            flush=True,
+        )
+        return f"error:{e!s}"[:200]
+
+    if r is None:
+        print(
+            json.dumps(
+                {
+                    "event": "uazapi_disconnect_notify_send_failed",
+                    "campaign_id": campaign_id,
+                    "instance_id": instance_id,
+                },
+                ensure_ascii=False,
+            ),
+            flush=True,
+        )
+        return "send_failed"
+    with conn.cursor() as cur:
+        cur.execute(
+            "UPDATE instances SET last_disconnect_notify_at = NOW() WHERE id = %s",
+            (instance_id,),
+        )
+    print(
+        json.dumps(
+            {
+                "event": "uazapi_disconnect_notify_sent",
+                "campaign_id": campaign_id,
+                "instance_id": instance_id,
+                "user_id": user_id,
+                **(ctx or {}),
+            },
+            ensure_ascii=False,
+        ),
+        flush=True,
+    )
+    return "sent"

--- a/worker_cadence.py
+++ b/worker_cadence.py
@@ -66,10 +66,14 @@ from utils.next_valid_uazapi_send import is_campaign_send_window, next_valid_sen
 from utils.campaign_send_policy import uazapi_initial_chunk_distribution_limits
 # Slot matinal automático do chunk initial: ``cadence_next_initial_send_slot`` em
 # ``utils/initial_chunk_schedule_target.py`` (sucessor de ``_next_initial_send_slot``).
-from utils.initial_chunk_schedule_target import (
-    cadence_next_send_datetime,
-    uazapi_same_day_initial_chunk_after_unlock_enabled,
-    resolve_initial_chunk_schedule_target,
+from utils.uazapi_error_taxonomy import (
+    classify_create_advanced_error,
+    format_last_error_for_db,
+)
+from utils.uazapi_support_notify import (
+    get_instance_status_cached,
+    is_instance_disconnected_status,
+    maybe_send_disconnect_support_whatsapp,
 )
 
 # Chatwoot Config
@@ -94,6 +98,25 @@ VERIFY_FOLDER_AFTER_SECONDS = 180  # list_folders 3 min após create_advanced_ca
 
 # Fila de verificação pós-create: (send_id, folder_id, token, verify_at)
 _verify_folder_queue = []
+
+
+def _next_retry_utc_for_materialize(camp_win, now_utc_naive, attempt_count):
+    """
+    Backoff exponencial (cap 30 min) alinhado à janela BRT: se cair fora, usa
+    next_valid_send_utc_naive a partir de agora.
+    """
+    m = 2 ** min(max(0, int(attempt_count or 0)), 4)
+    m = max(1, min(int(m), 30))
+    cand = now_utc_naive + timedelta(minutes=m)
+    if getattr(cand, "tzinfo", None) is None:
+        br = pytz.UTC.localize(cand).astimezone(BRAZIL_TZ)
+    else:
+        br = cand.astimezone(BRAZIL_TZ)
+    if is_campaign_send_window(camp_win, now_brazil=br):
+        return cand
+    return next_valid_send_utc_naive(
+        camp_win, now_utc_naive, margin_minutes=0
+    )
 
 
 def _reconcile_find_before_rollover_enabled():
@@ -783,14 +806,15 @@ def _materialize_scheduled_stage_sends(conn, force_send_ids=None):
                 SELECT css.id, css.campaign_id, css.stage, css.instance_id, css.scheduled_for,
                        css.status, i.apikey,
                        css.delay_min_minutes, css.delay_max_minutes, css.message_variations, css.lead_ids,
+                       css.materialize_attempt_count,
                        c.delay_min_minutes AS campaign_delay_min, c.delay_max_minutes AS campaign_delay_max,
                        c.send_hour_start, c.send_hour_end, c.send_saturday, c.send_sunday, c.use_uazapi_sender,
-                       c.daily_limit
+                       c.daily_limit, c.user_id
                 FROM campaign_stage_sends css
                 JOIN campaigns c ON c.id = css.campaign_id
                 JOIN instances i ON i.id = css.instance_id
                 WHERE css.id = ANY(%s)
-                  AND css.status = 'scheduled'
+                  AND css.status IN ('scheduled', 'waiting_reconnect')
                   AND css.uazapi_folder_id IS NULL
                   AND css.scheduled_for IS NOT NULL
                 ORDER BY css.scheduled_for ASC, css.id ASC
@@ -805,13 +829,14 @@ def _materialize_scheduled_stage_sends(conn, force_send_ids=None):
                 SELECT css.id, css.campaign_id, css.stage, css.instance_id, css.scheduled_for,
                        css.status, i.apikey,
                        css.delay_min_minutes, css.delay_max_minutes, css.message_variations, css.lead_ids,
+                       css.materialize_attempt_count,
                        c.delay_min_minutes AS campaign_delay_min, c.delay_max_minutes AS campaign_delay_max,
                        c.send_hour_start, c.send_hour_end, c.send_saturday, c.send_sunday, c.use_uazapi_sender,
-                       c.daily_limit
+                       c.daily_limit, c.user_id
                 FROM campaign_stage_sends css
                 JOIN campaigns c ON c.id = css.campaign_id
                 JOIN instances i ON i.id = css.instance_id
-                WHERE css.status = 'scheduled'
+                WHERE css.status IN ('scheduled', 'waiting_reconnect')
                   AND css.uazapi_folder_id IS NULL
                   AND css.scheduled_for IS NOT NULL
                   AND css.scheduled_for <= ((NOW() AT TIME ZONE 'UTC') + (%s * INTERVAL '1 minute'))
@@ -986,7 +1011,6 @@ def _materialize_scheduled_stage_sends(conn, force_send_ids=None):
                 "send_sunday": send.get("send_sunday"),
             }
             if send.get("use_uazapi_sender") and not is_campaign_send_window(camp_win):
-                sched_for = send.get("scheduled_for") or scheduled_for
                 if sched_for:
                     rem_sec = (sched_for - now_utc_naive).total_seconds()
                     within_materialize = (
@@ -1022,7 +1046,7 @@ def _materialize_scheduled_stage_sends(conn, force_send_ids=None):
                             """
                             UPDATE campaign_stage_sends
                             SET status = 'failed', updated_at = NOW()
-                            WHERE id = %s AND status = 'scheduled'
+                            WHERE id = %s AND status IN ('scheduled', 'waiting_reconnect')
                             """,
                             (send_id,),
                         )
@@ -1040,7 +1064,7 @@ def _materialize_scheduled_stage_sends(conn, force_send_ids=None):
                         """
                         UPDATE campaign_stage_sends
                         SET scheduled_for = %s, updated_at = NOW()
-                        WHERE id = %s AND status = 'scheduled'
+                        WHERE id = %s AND status IN ('scheduled', 'waiting_reconnect')
                         """,
                         (next_sf, send_id),
                     )
@@ -1110,16 +1134,59 @@ def _materialize_scheduled_stage_sends(conn, force_send_ids=None):
                 conn.commit()
                 continue
 
-            delay_fallback_min = int(send.get("delay_min_minutes") or send.get("campaign_delay_min") or 5)
-            delay_fallback_max = int(send.get("delay_max_minutes") or send.get("campaign_delay_max") or 15)
+            # Reserva: persistir lead_ids + planned_count antes de POST (retomada e exclusão)
+            with conn.cursor() as cur:
+                pl = [c["id"] for c in chunk if c and c.get("id") is not None]
+                cur.execute(
+                    """
+                    UPDATE campaign_stage_sends
+                    SET lead_ids = %s,
+                        planned_count = %s,
+                        message_variations = %s,
+                        status = 'scheduled',
+                        updated_at = NOW()
+                    WHERE id = %s AND uazapi_folder_id IS NULL
+                    """,
+                    (json.dumps(pl), len(pl), Json(step_msgs), send_id),
+                )
+            conn.commit()
+            reloaded = dict(send)
+            reloaded['materialize_attempt_count'] = int(
+                (send.get("materialize_attempt_count") or 0) or 0
+            )
+            reloaded["lead_ids"] = pl
+
+            delay_fallback_min = int(
+                reloaded.get("delay_min_minutes")
+                or reloaded.get("campaign_delay_min")
+                or 5
+            )
+            delay_fallback_max = int(
+                reloaded.get("delay_max_minutes")
+                or reloaded.get("campaign_delay_max")
+                or 15
+            )
             if delay_fallback_max < delay_fallback_min:
                 delay_fallback_max = delay_fallback_min
+            reloaded["delay_min_minutes"] = delay_fallback_min
+            reloaded["delay_max_minutes"] = delay_fallback_max
+            rechunk = [c for c in chunk if c.get("id") in set(pl)]
+            if not rechunk and pl:
+                with conn.cursor() as cur:
+                    cur.execute(
+                        "UPDATE campaign_stage_sends SET status = 'failed', last_materialize_error = %s, updated_at = NOW() WHERE id = %s",
+                        (json.dumps({"error": "reserved_leads_mismatch"}), send_id),
+                    )
+                conn.commit()
+                break
 
-            use_pacing = bool(send.get("use_uazapi_sender")) and stage == "initial" and len(chunk) >= 2
+            use_pacing = (
+                bool(reloaded.get("use_uazapi_sender")) and stage == "initial" and len(rechunk) >= 2
+            )
             if use_pacing:
-                pacing_plan = build_pacing_segments_for_leads(chunk)
+                pacing_plan = build_pacing_segments_for_leads(rechunk)
             else:
-                pacing_plan = [(tuple(chunk), delay_fallback_min, delay_fallback_max, 0)]
+                pacing_plan = [(tuple(rechunk), delay_fallback_min, delay_fallback_max, 0)]
 
             t_chain = now_utc_naive
             prev_sub, prev_dmin, prev_dmax, prev_gap = None, None, None, 0
@@ -1129,6 +1196,76 @@ def _materialize_scheduled_stage_sends(conn, force_send_ids=None):
 
             for seg_i, (sub_chunk_t, dmin, dmax, gap_after) in enumerate(pacing_plan):
                 sub_chunk = list(sub_chunk_t)
+                if (
+                    seg_i == 0
+                    and sub_chunk
+                    and send.get("use_uazapi_sender")
+                ):
+                    iid = send.get("instance_id")
+                    st_payload = get_instance_status_cached(
+                        uazapi_service, int(iid), (token or "").strip()
+                    )
+                    if is_instance_disconnected_status(st_payload):
+                        uid = send.get("user_id")
+                        print(
+                            json.dumps(
+                                {
+                                    "event": "uazapi_materialize_blocked_disconnected",
+                                    "campaign_id": campaign_id,
+                                    "send_id": send_id,
+                                    "instance_id": iid,
+                                },
+                                ensure_ascii=False,
+                            ),
+                            flush=True,
+                        )
+                        with conn.cursor() as cur:
+                            cur.execute(
+                                """
+                                UPDATE campaign_stage_sends
+                                SET status = 'waiting_reconnect',
+                                    scheduled_for = %s,
+                                    last_materialize_error = %s,
+                                    materialize_attempt_count = %s,
+                                    updated_at = NOW()
+                                WHERE id = %s
+                                """,
+                                (
+                                    now_utc_naive + timedelta(minutes=2),
+                                    format_last_error_for_db(
+                                        {
+                                            "uazapi_request_failed": True,
+                                            "error_body": "instance_status_disconnected",
+                                        },
+                                        "no_session",
+                                    ),
+                                    int((reloaded.get("materialize_attempt_count") or 0) or 0) + 1,
+                                    send_id,
+                                ),
+                            )
+                        conn.commit()
+                        if uid:
+                            try:
+                                maybe_send_disconnect_support_whatsapp(
+                                    conn,
+                                    uazapi_service,
+                                    campaign_id=campaign_id,
+                                    user_id=int(uid),
+                                    instance_id=int(iid),
+                                )
+                            except Exception as _ex:
+                                print(
+                                    json.dumps(
+                                        {
+                                            "event": "uazapi_support_notify_ex",
+                                            "error": str(_ex)[:400],
+                                        },
+                                        ensure_ascii=False,
+                                    ),
+                                    flush=True,
+                                )
+                        break
+
                 messages, lead_ids = _build_messages_for_sub(sub_chunk, step_msgs)
                 if not messages:
                     print(
@@ -1190,13 +1327,121 @@ def _materialize_scheduled_stage_sends(conn, force_send_ids=None):
                     info=f"Campaign {campaign_id} {stage} inst {send.get('instance_id')} seg0",
                 )
                 folder_id = (result or {}).get("folder_id") or (result or {}).get("folderId")
+                cat, _msg, _http = classify_create_advanced_error(result)
                 if not result or not folder_id:
-                    err_msg = (result or {}).get("error") or (result or {}).get("message") or str(result)
-                    print(f"  ❌ [Materialize] campaign_id={campaign_id} inst={send.get('instance_id')}: Uazapi create_advanced_campaign falhou. folder_id={folder_id} err={err_msg}")
+                    err_msg = (result or {}).get("error") or (result or {}).get("message")
+                    if err_msg is None and isinstance(result, dict) and result.get(
+                        "uazapi_request_failed"
+                    ):
+                        err_msg = str(
+                            (result.get("error_body") or result.get("exception") or "")
+                        )[:500]
+                    print(
+                        f"  ❌ [Materialize] campaign_id={campaign_id} inst={send.get('instance_id')}: "
+                        f"Uazapi create_advanced_campaign falhou. folder_id={folder_id} err={err_msg!s} class={cat}"
+                    )
+                    le = format_last_error_for_db(result, cat)
+                    ac = int((reloaded.get("materialize_attempt_count") or 0) or 0)
+                    uid = send.get("user_id")
+                    if cat == "no_session" and uid:
+                        try:
+                            maybe_send_disconnect_support_whatsapp(
+                                conn,
+                                uazapi_service,
+                                campaign_id=campaign_id,
+                                user_id=int(uid),
+                                instance_id=int(send.get("instance_id") or 0),
+                            )
+                        except Exception as _ex:
+                            print(
+                                json.dumps(
+                                    {
+                                        "event": "uazapi_support_notify_ex",
+                                        "error": str(_ex)[:400],
+                                    },
+                                    ensure_ascii=False,
+                                ),
+                                flush=True,
+                            )
+                    if cat == "no_session":
+                        with conn.cursor() as cur:
+                            cur.execute(
+                                """
+                                UPDATE campaign_stage_sends
+                                SET status = 'waiting_reconnect',
+                                    scheduled_for = %s,
+                                    last_materialize_error = %s,
+                                    materialize_attempt_count = %s,
+                                    updated_at = NOW()
+                                WHERE id = %s
+                                """,
+                                (
+                                    now_utc_naive + timedelta(minutes=2),
+                                    le,
+                                    ac + 1,
+                                    send_id,
+                                ),
+                            )
+                        conn.commit()
+                        break
+                    if cat in (
+                        "transient_http",
+                        "empty_response",
+                        "server_error",
+                    ) and ac < 5:
+                        try:
+                            next_sf = _next_retry_utc_for_materialize(
+                                camp_win, now_utc_naive, ac
+                            )
+                        except ValueError as vex:
+                            with conn.cursor() as cur:
+                                cur.execute(
+                                    """
+                                    UPDATE campaign_stage_sends
+                                    SET status = 'failed',
+                                        last_materialize_error = %s,
+                                        materialize_attempt_count = %s,
+                                        updated_at = NOW()
+                                    WHERE id = %s
+                                    """,
+                                    (
+                                        (le or "")[:1500]
+                                        + json.dumps(
+                                            {"next_valid_error": str(vex)},
+                                            ensure_ascii=False,
+                                        )[:200],
+                                        ac + 1,
+                                        send_id,
+                                    ),
+                                )
+                            conn.commit()
+                            break
+                        with conn.cursor() as cur:
+                            cur.execute(
+                                """
+                                UPDATE campaign_stage_sends
+                                SET status = 'scheduled',
+                                    scheduled_for = %s,
+                                    last_materialize_error = %s,
+                                    materialize_attempt_count = %s,
+                                    updated_at = NOW()
+                                WHERE id = %s
+                                """,
+                                (next_sf, le, ac + 1, send_id),
+                            )
+                        conn.commit()
+                        break
                     with conn.cursor() as cur:
                         cur.execute(
-                            "UPDATE campaign_stage_sends SET status = 'failed', updated_at = NOW() WHERE id = %s",
-                            (send_id,),
+                            """
+                            UPDATE campaign_stage_sends
+                            SET status = 'failed',
+                                last_materialize_error = %s,
+                                materialize_attempt_count = %s,
+                                updated_at = NOW()
+                            WHERE id = %s
+                            """,
+                            (le, ac + 1, send_id),
                         )
                     conn.commit()
                     break
@@ -1223,6 +1468,8 @@ def _materialize_scheduled_stage_sends(conn, force_send_ids=None):
                             delay_max_minutes = %s,
                             message_variations = %s,
                             status = 'running',
+                            last_materialize_error = NULL,
+                            materialize_attempt_count = 0,
                             updated_at = NOW()
                         WHERE id = %s
                         """,
@@ -1256,7 +1503,56 @@ def _materialize_scheduled_stage_sends(conn, force_send_ids=None):
     return {"folders_created": folders_created}
 
 
-def _process_verify_folder_queue():
+def _resume_waiting_reconnect_stage_sends(conn):
+    """
+    Tenta reativar ``waiting_reconnect`` quando a instância Uazapi volta a ``connected``,
+    puxa ``get_status`` e promove a linha a ``scheduled`` (mantém reserva em lead_ids).
+    """
+    if not uazapi_service:
+        return
+    with conn.cursor(cursor_factory=RealDictCursor) as cur:
+        cur.execute(
+            """
+            SELECT css.id, css.instance_id, i.apikey
+            FROM campaign_stage_sends css
+            JOIN instances i ON i.id = css.instance_id
+            WHERE css.status = 'waiting_reconnect'
+              AND css.uazapi_folder_id IS NULL
+              AND css.scheduled_for <= (NOW() AT TIME ZONE 'UTC')
+            LIMIT 30
+            """
+        )
+        rows = cur.fetchall() or []
+    for r in rows:
+        sid = r.get("id")
+        iid = r.get("instance_id")
+        tok = (r.get("apikey") or "").strip()
+        st = get_instance_status_cached(
+            uazapi_service, int(iid or 0), tok
+        )
+        if st and not is_instance_disconnected_status(st):
+            nxt = datetime.utcnow() + timedelta(seconds=30)
+            with conn.cursor() as cur:
+                cur.execute(
+                    """
+                    UPDATE campaign_stage_sends
+                    SET status = 'scheduled', scheduled_for = %s, updated_at = NOW()
+                    WHERE id = %s AND status = 'waiting_reconnect'
+                    """,
+                    (nxt, sid),
+                )
+            conn.commit()
+            print(
+                json.dumps(
+                    {
+                        "event": "uazapi_waiting_reconnect_resumed",
+                        "send_id": sid,
+                        "instance_id": iid,
+                    },
+                    ensure_ascii=False,
+                ),
+                flush=True,
+            )
     """
     Processa fila de verificação: 3 min após create_advanced_campaign, chama list_folders
     e confirma se folder existe e status em (queued, scheduled, sending). Log único por send.
@@ -1367,6 +1663,9 @@ def process_cadence():
     while True:
         try:
             conn = get_db_connection()
+
+            # Reativar waiting_reconnect quando a instância Uazapi reconecta
+            _resume_waiting_reconnect_stage_sends(conn)
 
             # T7: recovery de ``scheduled`` initial sem pasta (TTL) antes do materialize — F1
             _recover_stale_scheduled_initial_uazapi_sends(conn)


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary
Implements Uazapi materialize resilience (see prior commits) **plus** admin UI to force initial chunk.

### Admin: Forçar chunk (novo)
- **Route:** `POST /api/admin/campaigns/force-initial-chunk` — `@admin_required`, CSRF (`X-CSRF-Token` / body `csrf_token`)
- **Behavior:** loads campaign by ID; optional exact `confirm_name`; runs `get_status` on each linked Uazapi instance; calls `_continue_initial_chunk_core(campaign_id, owner_user_id, cancel_scheduled=…)` so it works for any campaign (uses owner id, not admin)
- **UI:** `templates/admin/campaigns.html` — button "Forçar chunk (Uazapi)" opens modal (campaign ID, optional name confirmation, checkbox to cancel scheduled/waiting_reconnect rows). Response JSON shown in panel; errors from API printed. Opening campaign details pre-fills the campaign ID field.
- **Server log:** one line per action with `admin_user`, `campaign_id`, `ok`, `http` status

### Env / DB
(unchanged from resilience commit) — `SUPPORT_UAZAPI_INSTANCE_TOKEN`, new user/instance columns, etc.

## Files (this commit)
- `app.py` — `_uazapi_instance_status_summary`, `admin_force_initial_chunk`
- `templates/admin/campaigns.html` — modal + CSRF from session
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-fa4cab12-2ad0-422e-9403-7d54f89613b6"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-fa4cab12-2ad0-422e-9403-7d54f89613b6"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

